### PR TITLE
feat(ButtonGroup): add ButtonGroup component with Storybook stories

### DIFF
--- a/hexawebshare/src/components/core/buttons/ButtonGroup.stories.svelte
+++ b/hexawebshare/src/components/core/buttons/ButtonGroup.stories.svelte
@@ -1,0 +1,122 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import ButtonGroupWrapper from './ButtonGroupWrapper.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/ButtonGroup',
+		component: ButtonGroupWrapper,
+		tags: ['autodocs'],
+		argTypes: {
+			orientation: {
+				control: { type: 'select' },
+				options: ['horizontal', 'vertical']
+			}
+		}
+	});
+</script>
+
+<!-- Default Horizontal Group -->
+<Story 
+	name="Horizontal" 
+	args={{ 
+		orientation: 'horizontal',
+		buttons: [
+			{ label: 'First', variant: 'primary' },
+			{ label: 'Second', variant: 'primary' },
+			{ label: 'Third', variant: 'primary' }
+		]
+	}} 
+/>
+
+<!-- Vertical Group -->
+<Story 
+	name="Vertical" 
+	args={{ 
+		orientation: 'vertical',
+		buttons: [
+			{ label: 'First', variant: 'primary' },
+			{ label: 'Second', variant: 'primary' },
+			{ label: 'Third', variant: 'primary' }
+		]
+	}} 
+/>
+
+<!-- Small Size -->
+<Story 
+	name="Small Size" 
+	args={{ 
+		buttons: [
+			{ label: 'Small', variant: 'primary', size: 'sm' },
+			{ label: 'Small', variant: 'primary', size: 'sm' },
+			{ label: 'Small', variant: 'primary', size: 'sm' }
+		]
+	}} 
+/>
+
+<!-- Medium Size -->
+<Story 
+	name="Medium Size" 
+	args={{ 
+		buttons: [
+			{ label: 'Medium', variant: 'primary', size: 'md' },
+			{ label: 'Medium', variant: 'primary', size: 'md' },
+			{ label: 'Medium', variant: 'primary', size: 'md' }
+		]
+	}} 
+/>
+
+<!-- Large Size -->
+<Story 
+	name="Large Size" 
+	args={{ 
+		buttons: [
+			{ label: 'Large', variant: 'primary', size: 'lg' },
+			{ label: 'Large', variant: 'primary', size: 'lg' },
+			{ label: 'Large', variant: 'primary', size: 'lg' }
+		]
+	}} 
+/>
+
+<!-- With Icons -->
+<Story 
+	name="With Icons" 
+	args={{ 
+		buttons: [
+			{ label: '✓ Save', variant: 'primary' },
+			{ label: '✏ Edit', variant: 'secondary' },
+			{ label: '🗑 Delete', variant: 'error' }
+		]
+	}} 
+/>
+
+<!-- Disabled States -->
+<Story 
+	name="Disabled States" 
+	args={{ 
+		buttons: [
+			{ label: 'Enabled', variant: 'primary' },
+			{ label: 'Disabled', variant: 'primary', disabled: true },
+			{ label: 'Enabled', variant: 'primary' }
+		]
+	}} 
+/>
+
+<!-- Mixed Button Variants -->
+<Story 
+	name="Mixed Variants" 
+	args={{ 
+		buttons: [
+			{ label: 'Primary', variant: 'primary' },
+			{ label: 'Secondary', variant: 'secondary' },
+			{ label: 'Accent', variant: 'accent' },
+			{ label: 'Info', variant: 'info' },
+			{ label: 'Success', variant: 'success' }
+		]
+	}} 
+/>
+

--- a/hexawebshare/src/components/core/buttons/ButtonGroup.svelte
+++ b/hexawebshare/src/components/core/buttons/ButtonGroup.svelte
@@ -2,3 +2,29 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	interface Props {
+		orientation?: 'horizontal' | 'vertical';
+		gap?: 'xs' | 'sm' | 'md' | 'lg';
+	}
+
+	const { orientation = 'horizontal', gap = 'sm', ...props }: Props = $props();
+
+	let groupClasses = $derived(
+		[
+			'flex',
+			orientation === 'vertical' ? 'flex-col' : 'flex-row',
+			gap === 'xs' && 'gap-1',
+			gap === 'sm' && 'gap-2',
+			gap === 'md' && 'gap-3',
+			gap === 'lg' && 'gap-4'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<div class={groupClasses} {...props}>
+	<slot />
+</div>

--- a/hexawebshare/src/components/core/buttons/ButtonGroupWrapper.svelte
+++ b/hexawebshare/src/components/core/buttons/ButtonGroupWrapper.svelte
@@ -1,0 +1,34 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script lang="ts">
+	import ButtonGroup from './ButtonGroup.svelte';
+	import Button from './Button.svelte';
+	
+	interface Props {
+		orientation?: 'horizontal' | 'vertical';
+		gap?: 'xs' | 'sm' | 'md' | 'lg';
+		buttons: Array<{
+			label: string;
+			variant?: 'primary' | 'secondary' | 'accent' | 'neutral' | 'info' | 'success' | 'warning' | 'error' | 'ghost' | 'link';
+			size?: 'xs' | 'sm' | 'md' | 'lg';
+			disabled?: boolean;
+		}>;
+	}
+	
+	const { orientation = 'horizontal', gap = 'sm', buttons }: Props = $props();
+</script>
+
+<ButtonGroup {orientation} {gap}>
+	{#each buttons as button}
+		<Button 
+			label={button.label} 
+			variant={button.variant || 'primary'} 
+			size={button.size || 'md'}
+			disabled={button.disabled || false}
+		/>
+	{/each}
+</ButtonGroup>
+


### PR DESCRIPTION
## 📄 Summary

Implements the ButtonGroup component for grouping multiple Button components together with proper spacing. This PR adds both the component implementation and comprehensive Storybook stories demonstrating all variants.

**Closes #9**

---

## 🧩 Affected Module(s)

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ Changes Made

### Component Implementation

- **ButtonGroup.svelte**: Core Svelte 5 component
  - TypeScript Props interface with `orientation` ('horizontal' | 'vertical') and `gap` ('xs' | 'sm' | 'md' | 'lg')
  - Uses Svelte 5 runes (`$props`, `$derived`)
  - Flexbox-based layout with Tailwind classes (DaisyUI's `btn-group` is deprecated in newer versions)
  - Supports horizontal and vertical orientations
  - Configurable gap spacing between buttons

- **ButtonGroupWrapper.svelte**: Storybook compatibility wrapper
  - Accepts buttons array as props
  - Renders ButtonGroup with Button children
  - Enables Storybook controls for interactive testing

### Storybook Stories

- **ButtonGroup.stories.svelte**: Comprehensive story collection
  - Default horizontal group
  - Vertical group
  - Different sizes (Small, Medium, Large)
  - With icons
  - Disabled states
  - Mixed button variants

---

## ✅ Checklist

- [x] My branch name follows format: `feat/add-button-group-component`
- [x] My PR title starts with one of the approved types: `feat`
- [x] My code is formatted (Prettier)
- [x] I ran type checking (svelte-check)
- [x] I tested in Storybook
- [x] I linked related issues: Closes #9
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #9

---

## 💬 Additional Notes

- Component uses flexbox instead of deprecated DaisyUI `btn-group` class for better flexibility
- Gap prop allows customizable spacing between buttons (xs, sm, md, lg)
- All stories render correctly in Storybook
- Component follows Svelte 5 runes pattern with TypeScript interfaces
- ButtonGroupWrapper enables Storybook's args-based story format for better controls