### PR TITLE
feat(SkeletonLoader): add skeleton loader component and stories

### DIFF
--- a/hexawebshare/src/components/core/feedback/SkeletonLoader.stories.svelte
+++ b/hexawebshare/src/components/core/feedback/SkeletonLoader.stories.svelte
@@ -1,0 +1,112 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import SkeletonLoader from './SkeletonLoader.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Feedback/SkeletonLoader',
+		component: SkeletonLoader,
+		tags: ['autodocs'],
+		argTypes: {
+			shape: {
+				control: { type: 'select' },
+				options: ['rect', 'text', 'pill', 'circle'],
+				description: 'Visual shape of the skeleton element'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['xs', 'sm', 'md', 'lg', 'xl'],
+				description: 'Height scale for the skeleton'
+			},
+			width: {
+				control: { type: 'select' },
+				options: ['short', 'medium', 'long', 'full'],
+				description: 'Width preset for rectangular or text skeletons'
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'base',
+					'neutral',
+					'primary',
+					'secondary',
+					'accent',
+					'info',
+					'success',
+					'warning',
+					'error'
+				],
+				description: 'Color theme of the skeleton'
+			},
+			lines: {
+				control: { type: 'number', min: 1, max: 10 },
+				description: 'Number of stacked lines (for text shape)'
+			},
+			gap: {
+				control: { type: 'select' },
+				options: ['none', 'sm', 'md'],
+				description: 'Vertical spacing between stacked lines'
+			},
+			animated: {
+				control: { type: 'boolean' },
+				description: 'Enable shimmer animation'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for assistive technologies'
+			}
+		},
+		args: {
+			shape: 'rect',
+			size: 'md',
+			width: 'medium',
+			variant: 'base',
+			lines: 1,
+			gap: 'sm',
+			animated: true,
+			ariaLabel: 'Loading content'
+		}
+	});
+</script>
+
+<Story name="Default" />
+
+<Story name="Text Lines" args={{ shape: 'text', lines: 3, width: 'long', gap: 'md' }} />
+
+<Story name="Circle" args={{ shape: 'circle', size: 'lg', variant: 'primary' }} />
+
+<Story name="Pill" args={{ shape: 'pill', size: 'sm', width: 'long', variant: 'accent' }} />
+
+<Story name="Full Width" args={{ shape: 'rect', width: 'full', size: 'lg', variant: 'neutral' }} />
+
+<Story
+	name="No Animation"
+	args={{ animated: false, shape: 'rect', width: 'long', variant: 'info' }}
+/>
+
+<Story name="Variant Showcase">
+	<div class="flex flex-col gap-4">
+		<SkeletonLoader variant="primary" width="long" />
+		<SkeletonLoader variant="secondary" width="long" />
+		<SkeletonLoader variant="success" width="long" />
+		<SkeletonLoader variant="warning" width="long" />
+		<SkeletonLoader variant="error" width="long" />
+	</div>
+</Story>
+
+<Story name="Card Placeholder">
+	<div class="flex flex-col gap-3 rounded-xl border border-base-200 p-4">
+		<div class="flex items-center gap-3">
+			<SkeletonLoader shape="circle" size="sm" variant="neutral" />
+			<div class="flex-1">
+				<SkeletonLoader shape="text" lines={2} width="long" gap="sm" />
+			</div>
+		</div>
+		<SkeletonLoader shape="rect" width="full" size="lg" />
+		<SkeletonLoader shape="text" lines={3} width="long" gap="sm" />
+	</div>
+</Story>

--- a/hexawebshare/src/components/core/feedback/SkeletonLoader.svelte
+++ b/hexawebshare/src/components/core/feedback/SkeletonLoader.svelte
@@ -2,3 +2,184 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	/**
+	 * Props for the SkeletonLoader component.
+	 */
+	interface Props {
+		/**
+		 * Visual shape of the skeleton element.
+		 * @default 'rect'
+		 */
+		shape?: 'rect' | 'text' | 'pill' | 'circle';
+		/**
+		 * Height scale for the skeleton.
+		 * @default 'md'
+		 */
+		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+		/**
+		 * Width preset for rectangular or text skeletons.
+		 * @default 'medium'
+		 */
+		width?: 'short' | 'medium' | 'long' | 'full';
+		/**
+		 * Color theme of the skeleton.
+		 * @default 'base'
+		 */
+		variant?:
+			| 'base'
+			| 'neutral'
+			| 'primary'
+			| 'secondary'
+			| 'accent'
+			| 'info'
+			| 'success'
+			| 'warning'
+			| 'error';
+		/**
+		 * Number of stacked lines (for text shape).
+		 * @default 1
+		 */
+		lines?: number;
+		/**
+		 * Vertical spacing between stacked lines.
+		 * @default 'sm'
+		 */
+		gap?: 'none' | 'sm' | 'md';
+		/**
+		 * Disable shimmer animation.
+		 * @default true
+		 */
+		animated?: boolean;
+		/**
+		 * Accessible label for assistive technologies.
+		 * @default 'Loading content'
+		 */
+		ariaLabel?: string;
+		/**
+		 * Additional CSS classes.
+		 */
+		class?: string;
+	}
+
+	const {
+		shape = 'rect',
+		size = 'md',
+		width = 'medium',
+		variant = 'base',
+		lines = 1,
+		gap = 'sm',
+		animated = true,
+		ariaLabel = 'Loading content',
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	const heightClasses = {
+		xs: 'h-3',
+		sm: 'h-4',
+		md: 'h-5',
+		lg: 'h-6',
+		xl: 'h-8'
+	} as const;
+
+	const widthClasses = {
+		short: 'w-16',
+		medium: 'w-28',
+		long: 'w-40',
+		full: 'w-full'
+	} as const;
+
+	const circleSizeClasses = {
+		xs: ['h-6', 'w-6'],
+		sm: ['h-8', 'w-8'],
+		md: ['h-10', 'w-10'],
+		lg: ['h-12', 'w-12'],
+		xl: ['h-16', 'w-16']
+	} as const;
+
+	const variantClasses = {
+		base: 'bg-base-300',
+		neutral: 'bg-neutral/30',
+		primary: 'bg-primary/30',
+		secondary: 'bg-secondary/30',
+		accent: 'bg-accent/30',
+		info: 'bg-info/30',
+		success: 'bg-success/30',
+		warning: 'bg-warning/30',
+		error: 'bg-error/30'
+	} as const;
+
+	const gapClasses = {
+		none: 'space-y-0',
+		sm: 'space-y-2',
+		md: 'space-y-3'
+	} as const;
+
+	let lineCount = $derived(Math.max(1, Math.min(lines, 10)));
+
+	const containerClasses = $derived(
+		['flex', 'flex-col', gapClasses[gap] ?? gapClasses.sm].join(' ')
+	);
+
+	const baseClasses = $derived(
+		[
+			'skeleton',
+			variantClasses[variant] ?? variantClasses.base,
+			shape !== 'circle' && heightClasses[size],
+			shape !== 'circle' && (shape === 'pill' ? 'rounded-full' : 'rounded-md'),
+			!animated && 'animate-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	const circleClasses = $derived(
+		[
+			'skeleton',
+			variantClasses[variant] ?? variantClasses.base,
+			'rounded-full',
+			...(circleSizeClasses[size] ?? circleSizeClasses.md),
+			!animated && 'animate-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	const pickWidthClass = (index: number): string => {
+		if (width === 'full') return widthClasses.full;
+
+		if (shape === 'text' && lineCount > 1 && index === lineCount - 1) {
+			if (width === 'long') return 'w-32';
+			if (width === 'medium') return 'w-24';
+			if (width === 'short') return 'w-14';
+		}
+
+		return widthClasses[width] ?? widthClasses.medium;
+	};
+</script>
+
+<div
+	class={containerClasses}
+	role="status"
+	aria-live="polite"
+	aria-busy="true"
+	aria-label={ariaLabel}
+	{...props}
+>
+	{#if shape === 'circle'}
+		<div class={circleClasses} aria-hidden="true"></div>
+	{:else}
+		{#each Array.from({ length: lineCount }) as _, index}
+			<div
+				class={[baseClasses, pickWidthClass(index), shape === 'text' && 'rounded']
+					.filter(Boolean)
+					.join(' ')}
+				aria-hidden="true"
+			></div>
+		{/each}
+	{/if}
+</div>


### PR DESCRIPTION
## 📄 Summary
- Implemented SkeletonLoader component (Svelte 5 runes, static DaisyUI classes, accessibility).
- Added comprehensive Storybook stories covering shapes, sizes, widths, variants, animation, and card example.

---

## 🧩 Affected Module(s)
- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format
(feat type, conventional commit format)

---

## ✅ Checklist
- [x] My branch name follows format: <type>/<short-description> (feat/add-skeleton-loader)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm lint -> prettier --check)
- [x] I ran static analysis (pnpm check)
- [x] I ran tests/builds successfully (pnpm build, pnpm build-storybook)
- [ ] I updated dependencies if needed (not needed)
- [x] For UI changes, I added stories (Storybook) 
- [x] I linked related issues using keywords

---

## 🔗 Related Issues
Closes #128

---

## 💬 Additional Notes (Optional)
- Known existing warning: ButtonGroup.svelte uses deprecated `<slot>`; not introduced by this change.