### PR TITLE
fix: replace deprecated slot with Svelte 5 snippet pattern in ButtonGroup

### DIFF
--- a/hexawebshare/src/components/core/buttons/ButtonGroup.svelte
+++ b/hexawebshare/src/components/core/buttons/ButtonGroup.svelte
@@ -4,12 +4,15 @@ SPDX-License-Identifier: MIT
 -->
 
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+
 	interface Props {
+		children: Snippet;
 		orientation?: 'horizontal' | 'vertical';
 		gap?: 'xs' | 'sm' | 'md' | 'lg';
 	}
 
-	const { orientation = 'horizontal', gap = 'sm', ...props }: Props = $props();
+	const { children, orientation = 'horizontal', gap = 'sm', ...props }: Props = $props();
 
 	let groupClasses = $derived(
 		[
@@ -26,5 +29,5 @@ SPDX-License-Identifier: MIT
 </script>
 
 <div class={groupClasses} {...props}>
-	<slot />
+	{@render children()}
 </div>

--- a/hexawebshare/src/components/core/buttons/ButtonGroupWrapper.svelte
+++ b/hexawebshare/src/components/core/buttons/ButtonGroupWrapper.svelte
@@ -32,12 +32,14 @@ SPDX-License-Identifier: MIT
 </script>
 
 <ButtonGroup {orientation} {gap}>
-	{#each buttons as button}
-		<Button
-			label={button.label}
-			variant={button.variant || 'primary'}
-			size={button.size || 'md'}
-			disabled={button.disabled || false}
-		/>
-	{/each}
+	{#snippet children()}
+		{#each buttons as button}
+			<Button
+				label={button.label}
+				variant={button.variant || 'primary'}
+				size={button.size || 'md'}
+				disabled={button.disabled || false}
+			/>
+		{/each}
+	{/snippet}
 </ButtonGroup>


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR fixes the Svelte 5 deprecation warning in `ButtonGroup.svelte` by replacing the deprecated `<slot />` syntax with the new Svelte 5 `Snippet` pattern. The component now uses `{@render children()}` instead of `<slot />`, ensuring full compatibility with Svelte 5 and removing the deprecation warning.

**Changes:**
- Replaced `<slot />` with `Snippet` pattern in `ButtonGroup.svelte`
- Updated `ButtonGroupWrapper.svelte` to use `{#snippet children()}` block
- Added proper TypeScript type imports for `Snippet`
- All existing functionality is preserved - the component works identically, just using the modern Svelte 5 API.

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

✅ PR title follows Conventional Commits format: `fix: replace deprecated slot with Svelte 5 snippet pattern in ButtonGroup`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: `fix/button-group-svelte5-snippet`
- [x] My PR title starts with one of the approved types listed above (`fix`)
- [x] My TypeScript/Svelte code is formatted (`pnpm format`)
- [x] I ran static analysis (`pnpm check`) and resolved warnings
- [x] I ran linting (`pnpm lint`) successfully
- [x] I tested in Storybook and verified all stories work correctly
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

> If this PR addresses one or more issues, link them here:

Fixes Svelte 5 deprecation warning: "Existing ButtonGroup.svelte uses <slot> (Svelte 5 deprecation warning)"---

## 💬 Additional Notes (Optional)

**Testing Instructions:**
1. Run `pnpm storybook` and navigate to `Core > ButtonGroup`
2. Verify all stories render correctly:
   - Horizontal
   - Vertical
   - Small Size
   - Medium Size
   - Large Size
   - With Icons
   - Disabled States
   - Mixed Variants
3. Confirm no deprecation warnings appear in console

**Technical Details:**
- Changed from `<slot />` to `{@render children()}` pattern
- Added `import type { Snippet } from 'svelte'` for proper TypeScript support
- Updated Props interface to include `children: Snippet`
- Modified `ButtonGroupWrapper.svelte` to wrap content with `{#snippet children()}`

**Breaking Changes:** None - this is a non-breaking change that maintains full backward compatibility at the API level.