### PR TITLE
feat(core): implement Dialog component with Storybook stories

### DIFF
--- a/hexawebshare/src/components/core/overlay-navigation/Dialog.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Dialog.stories.svelte
@@ -1,0 +1,135 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Dialog from './Dialog.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Overlay Navigation/Dialog',
+		component: Dialog,
+		tags: ['autodocs'],
+		argTypes: {
+			open: {
+				control: 'boolean',
+				description: 'Whether the dialog is open'
+			},
+			title: {
+				control: 'text',
+				description: 'Dialog title'
+			},
+			description: {
+				control: 'text',
+				description: 'Dialog description text'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['xs', 'sm', 'md', 'lg', 'xl'],
+				description: 'Size of the dialog'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for screen readers'
+			},
+			ariaLabelledBy: {
+				control: 'text',
+				description: 'ID of element that labels the dialog'
+			}
+		},
+		args: {
+			open: true,
+			title: 'Dialog Title',
+			size: 'md'
+		}
+	});
+</script>
+
+<!-- Default Story -->
+<Story
+	name="Default"
+	args={{
+		open: true,
+		title: 'Dialog Title',
+		description: 'This is a default dialog with a title and description.',
+		size: 'md'
+	}}
+/>
+
+<!-- Size Stories -->
+<Story
+	name="Extra Small"
+	args={{
+		open: true,
+		title: 'Extra Small Dialog',
+		description: 'This is an extra small dialog.',
+		size: 'xs'
+	}}
+/>
+<Story
+	name="Small"
+	args={{ open: true, title: 'Small Dialog', description: 'This is a small dialog.', size: 'sm' }}
+/>
+<Story
+	name="Medium"
+	args={{ open: true, title: 'Medium Dialog', description: 'This is a medium dialog.', size: 'md' }}
+/>
+<Story
+	name="Large"
+	args={{ open: true, title: 'Large Dialog', description: 'This is a large dialog.', size: 'lg' }}
+/>
+<Story
+	name="Extra Large"
+	args={{
+		open: true,
+		title: 'Extra Large Dialog',
+		description: 'This is an extra large dialog.',
+		size: 'xl'
+	}}
+/>
+
+<!-- Content Stories -->
+<Story
+	name="With Description"
+	args={{
+		open: true,
+		title: 'Dialog with Description',
+		description: 'This dialog includes a detailed description to provide more context to the user.',
+		size: 'md'
+	}}
+/>
+<Story name="Title Only" args={{ open: true, title: 'Dialog Title Only', size: 'md' }} />
+
+<!-- Accessibility Stories -->
+<Story
+	name="With Aria Label"
+	args={{
+		open: true,
+		title: 'Accessible Dialog',
+		description: 'This dialog has a custom aria-label.',
+		ariaLabel: 'Custom dialog label',
+		size: 'md'
+	}}
+/>
+<Story
+	name="With Aria Labelled By"
+	args={{
+		open: true,
+		title: 'Dialog with Custom Label',
+		description: 'This dialog uses aria-labelledby.',
+		ariaLabelledBy: 'custom-title',
+		size: 'md'
+	}}
+/>
+
+<!-- Interactive Examples -->
+<Story
+	name="Playground"
+	args={{
+		open: true,
+		title: 'Dialog Playground',
+		description: 'Use the controls to customize this dialog.',
+		size: 'md'
+	}}
+/>

--- a/hexawebshare/src/components/core/overlay-navigation/Dialog.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Dialog.svelte
@@ -2,3 +2,118 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	interface Props {
+		open: boolean;
+		title: string;
+		description?: string;
+		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+		onClose?: () => void;
+		ariaLabel?: string;
+		ariaLabelledBy?: string;
+		class?: string;
+	}
+
+	const {
+		open,
+		title,
+		description,
+		size = 'md',
+		onClose,
+		ariaLabel,
+		ariaLabelledBy,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	let modalClasses = $derived(['modal', open && 'modal-open', className].filter(Boolean).join(' '));
+
+	let modalBoxClasses = $derived(
+		[
+			'modal-box',
+			size === 'xs' && 'max-w-xs',
+			size === 'sm' && 'max-w-sm',
+			size === 'md' && 'max-w-md',
+			size === 'lg' && 'max-w-lg',
+			size === 'xl' && 'max-w-xl'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	let titleId = $derived(`dialog-title-${Math.random().toString(36).substr(2, 9)}`);
+	let descriptionId = $derived(`dialog-description-${Math.random().toString(36).substr(2, 9)}`);
+
+	let modalElement = $state<HTMLDivElement | null>(null);
+	let previousActiveElement = $state<HTMLElement | null>(null);
+
+	// Handle ESC key to close dialog
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && open && onClose) {
+			onClose();
+		}
+	}
+
+	// Focus trap: Store previous active element and focus modal when opened
+	$effect(() => {
+		if (open) {
+			previousActiveElement = document.activeElement as HTMLElement;
+			// Focus the modal box when it opens
+			setTimeout(() => {
+				if (modalElement) {
+					const focusableElement = modalElement.querySelector<HTMLElement>(
+						'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+					);
+					focusableElement?.focus();
+				}
+			}, 0);
+		} else if (previousActiveElement) {
+			// Restore focus when modal closes
+			previousActiveElement.focus();
+		}
+	});
+
+	onMount(() => {
+		document.addEventListener('keydown', handleKeyDown);
+		return () => {
+			document.removeEventListener('keydown', handleKeyDown);
+		};
+	});
+</script>
+
+{#if open}
+	<div
+		bind:this={modalElement}
+		class={modalClasses}
+		role="dialog"
+		aria-modal="true"
+		aria-label={ariaLabel}
+		aria-labelledby={ariaLabelledBy || titleId}
+		aria-describedby={description ? descriptionId : undefined}
+		{...props}
+	>
+		<div class={modalBoxClasses}>
+			<h3 id={titleId} class="text-lg font-bold">
+				{title}
+			</h3>
+			{#if description}
+				<p id={descriptionId} class="py-4">
+					{description}
+				</p>
+			{/if}
+		</div>
+		<form method="dialog">
+			<button
+				class="btn btn-circle btn-ghost btn-sm absolute right-2 top-2"
+				onclick={onClose}
+				aria-label="Close dialog"
+				type="button"
+			>
+				✕
+			</button>
+		</form>
+	</div>
+{/if}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements the Dialog component as requested in issue #79. The Dialog component is a modal dialog UI element that follows Svelte 5 patterns with runes, uses DaisyUI styling, and includes comprehensive accessibility features.

**Key Features:**
- TypeScript Props interface with full type safety
- Svelte 5 runes ($props, $derived, $state, $effect) for reactivity
- DaisyUI styling with static classes (no dynamic string interpolation)
- Support for 5 sizes: xs, sm, md, lg, xl
- Title and optional description support
- Full accessibility support (ARIA labels, aria-labelledby, aria-describedby, role="dialog", aria-modal)
- ESC key support to close dialog
- Focus trap implementation (focus management when modal opens/closes)
- Close button with proper ARIA label
- Comprehensive Storybook stories covering all variants, sizes, and accessibility features

**Component Location:** `hexawebshare/src/components/core/overlay-navigation/Dialog.svelte`

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

✅ PR title follows Conventional Commits format: `feat(core): implement Dialog component with Storybook stories`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (feat/implement-dialog-component)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (pnpm build, pnpm build-storybook)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes (no new dependencies required)
- [x] For UI changes, I added Storybook stories demonstrating all variants
- [x] I linked related issues using keywords like Closes #79
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

> If this PR addresses one or more issues, link them here:

Closes #79---

## 💬 Additional Notes (Optional)

**Testing Instructions:**
1. Run `pnpm storybook` to view the component in Storybook
2. Navigate to `Core/Overlay Navigation/Dialog` in the Storybook sidebar
3. Test all size variants: Extra Small, Small, Medium, Large, Extra Large
4. Test content variants: Default, With Description, Title Only
5. Test accessibility stories: "With Aria Label" and "With Aria Labelled By"
6. Test interactive features:
   - ESC key closes the dialog (when `onClose` callback is provided)
   - Close button (✕) closes the dialog
   - Focus trap: When modal opens, focus moves to first focusable element inside modal
   - When modal closes, focus returns to previous active element
7. Use the Playground story to interactively test different prop combinations

**Component Export:**
The component is exported in `src/lib/index.ts` as `Dialog`.

**Accessibility Features:**
- `role="dialog"` for semantic HTML
- `aria-modal="true"` to indicate modal behavior
- `aria-labelledby` linking to title element
- `aria-describedby` linking to description element (when provided)
- `aria-label` support for custom labels
- ESC key support for keyboard navigation
- Focus trap for proper focus management
- Close button with `aria-label="Close dialog"`

**Technical Details:**
- Uses DaisyUI `modal` and `modal-box` classes
- Size variants use Tailwind `max-w-*` classes (xs, sm, md, lg, xl)
- Svelte 5 `$effect` for focus management
- `onMount` for ESC key event listener setup
- Proper cleanup of event listeners on component destroy