### PR TITLE
feat(core): implement Dialog component with Storybook stories

### DIFF
--- a/hexawebshare/src/components/core/overlay-navigation/Dialog.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Dialog.stories.svelte
@@ -29,6 +29,14 @@ SPDX-License-Identifier: MIT
 				options: ['xs', 'sm', 'md', 'lg', 'xl'],
 				description: 'Size of the dialog'
 			},
+			closable: {
+				control: 'boolean',
+				description: 'Show close button'
+			},
+			closeOnBackdropClick: {
+				control: 'boolean',
+				description: 'Close dialog when clicking backdrop'
+			},
 			ariaLabel: {
 				control: 'text',
 				description: 'Accessible label for screen readers'
@@ -122,6 +130,17 @@ SPDX-License-Identifier: MIT
 		size: 'md'
 	}}
 />
+
+<!-- With Children/Content -->
+<Story name="With Custom Content">
+	<Dialog open={true} title="Delete Confirmation" size="md">
+		<p>Are you sure you want to delete this item? This action cannot be undone.</p>
+		<div class="modal-action">
+			<button class="btn">Cancel</button>
+			<button class="btn btn-error">Delete</button>
+		</div>
+	</Dialog>
+</Story>
 
 <!-- Interactive Examples -->
 <Story

--- a/hexawebshare/src/lib/index.ts
+++ b/hexawebshare/src/lib/index.ts
@@ -8,3 +8,6 @@ export { default as ButtonGroup } from '../components/core/buttons/ButtonGroup.s
 // Core - Feedback
 export { default as Spinner } from '../components/core/feedback/Spinner.svelte';
 export { default as Loader } from '../components/core/feedback/Loader.svelte';
+
+// Core - Overlay Navigation
+export { default as Dialog } from '../components/core/overlay-navigation/Dialog.svelte';


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements the Dialog component as requested in issue #79. The Dialog component is a modal dialog UI element that follows Svelte 5 patterns with runes, uses DaisyUI styling, and includes comprehensive accessibility features.

**Key Features:**
- TypeScript Props interface with full type safety
- Svelte 5 runes ($props, $derived, $state, $effect) for reactivity
- DaisyUI styling with static classes (no dynamic string interpolation)
- Support for 5 sizes: xs, sm, md, lg, xl
- Title and optional description support
- Full accessibility support (ARIA labels, aria-labelledby, aria-describedby, role="dialog", aria-modal)
- ESC key support to close dialog
- Focus trap implementation (focus management when modal opens/closes)
- Close button with proper ARIA label
- Comprehensive Storybook stories covering all variants, sizes, and accessibility features

**Component Location:** `hexawebshare/src/components/core/overlay-navigation/Dialog.svelte`

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

✅ PR title follows Conventional Commits format: `feat(core): implement Dialog component with Storybook stories`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (feat/implement-dialog-component)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (pnpm build, pnpm build-storybook)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes (no new dependencies required)
- [x] For UI changes, I added Storybook stories demonstrating all variants
- [x] I linked related issues using keywords like Closes #79
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

> If this PR addresses one or more issues, link them here:

Closes #79---

## 💬 Additional Notes (Optional)

**Testing Instructions:**
1. Run `pnpm storybook` to view the component in Storybook
2. Navigate to `Core/Overlay Navigation/Dialog` in the Storybook sidebar
3. Test all size variants: Extra Small, Small, Medium, Large, Extra Large
4. Test content variants: Default, With Description, Title Only
5. Test accessibility stories: "With Aria Label" and "With Aria Labelled By"
6. Test interactive features:
   - ESC key closes the dialog (when `onClose` callback is provided)
   - Close button (✕) closes the dialog
   - Focus trap: When modal opens, focus moves to first focusable element ins