### PR TITLE
feat(CardSection): implement CardSection component with Storybook sto…

### DIFF
--- a/hexawebshare/src/components/core/layout/CardSection.stories.svelte
+++ b/hexawebshare/src/components/core/layout/CardSection.stories.svelte
@@ -1,0 +1,289 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import CardSectionWrapper from './CardSectionWrapper.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Layout/CardSection',
+		component: CardSectionWrapper,
+		tags: ['autodocs'],
+		argTypes: {
+			title: {
+				control: 'text',
+				description: 'Section title/heading'
+			},
+			description: {
+				control: 'text',
+				description: 'Section description text'
+			},
+			variant: {
+				control: { type: 'select' },
+				options: ['default', 'bordered', 'filled', 'ghost'],
+				description: 'Visual variant of the section'
+			},
+			padding: {
+				control: { type: 'select' },
+				options: ['none', 'xs', 'sm', 'md', 'lg', 'xl'],
+				description: 'Padding size for the section'
+			},
+			collapsible: {
+				control: 'boolean',
+				description: 'Whether the section is collapsible'
+			},
+			collapsed: {
+				control: 'boolean',
+				description: 'Whether the section is initially collapsed'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Whether the section is disabled'
+			},
+			loading: {
+				control: 'boolean',
+				description: 'Whether the section is in loading state'
+			},
+			divider: {
+				control: 'boolean',
+				description: 'Whether to show a divider at the bottom'
+			},
+			showIcon: {
+				control: 'boolean',
+				description: 'Show an icon before the title'
+			},
+			showHeaderActions: {
+				control: 'boolean',
+				description: 'Show header action buttons'
+			},
+			content: {
+				control: 'text',
+				description: 'Content text for the section'
+			}
+		},
+		args: {
+			title: 'Section Title',
+			variant: 'default',
+			padding: 'md',
+			content: 'This is the card section content. It can contain any type of content.'
+		}
+	});
+</script>
+
+<!-- Default Story -->
+<Story
+	name="Default"
+	args={{
+		title: 'Section Title',
+		padding: 'md',
+		variant: 'default',
+		content:
+			'This is the default card section with some content inside. It can contain any type of content including text, forms, or other components.'
+	}}
+/>
+
+<!-- With Title and Description -->
+<Story
+	name="With Description"
+	args={{
+		title: 'Account Settings',
+		description: 'Manage your account preferences and security settings',
+		content: 'Your account details and preferences are shown here.'
+	}}
+/>
+
+<!-- Variant Stories -->
+<Story
+	name="Bordered"
+	args={{
+		title: 'Bordered Section',
+		variant: 'bordered',
+		content: 'This section has a visible border around it.'
+	}}
+/>
+
+<Story
+	name="Filled"
+	args={{
+		title: 'Filled Section',
+		variant: 'filled',
+		content: 'This section has a filled background.'
+	}}
+/>
+
+<Story
+	name="Ghost"
+	args={{
+		title: 'Ghost Section',
+		variant: 'ghost',
+		content: 'This section has a transparent background.'
+	}}
+/>
+
+<!-- Padding Variants -->
+<Story
+	name="No Padding"
+	args={{
+		title: 'No Padding',
+		padding: 'none',
+		variant: 'bordered',
+		content: 'This section has no padding.'
+	}}
+/>
+
+<Story
+	name="Extra Small Padding"
+	args={{
+		title: 'XS Padding',
+		padding: 'xs',
+		variant: 'bordered',
+		content: 'This section has extra small padding.'
+	}}
+/>
+
+<Story
+	name="Small Padding"
+	args={{
+		title: 'SM Padding',
+		padding: 'sm',
+		variant: 'bordered',
+		content: 'This section has small padding.'
+	}}
+/>
+
+<Story
+	name="Medium Padding"
+	args={{
+		title: 'MD Padding',
+		padding: 'md',
+		variant: 'bordered',
+		content: 'This section has medium padding (default).'
+	}}
+/>
+
+<Story
+	name="Large Padding"
+	args={{
+		title: 'LG Padding',
+		padding: 'lg',
+		variant: 'bordered',
+		content: 'This section has large padding.'
+	}}
+/>
+
+<Story
+	name="Extra Large Padding"
+	args={{
+		title: 'XL Padding',
+		padding: 'xl',
+		variant: 'bordered',
+		content: 'This section has extra large padding.'
+	}}
+/>
+
+<!-- Collapsible Stories -->
+<Story
+	name="Collapsible"
+	args={{
+		title: 'Collapsible Section',
+		description: 'Click to expand or collapse',
+		collapsible: true,
+		content:
+			'This content can be hidden by clicking on the header. Great for organizing complex forms or long content.'
+	}}
+/>
+
+<Story
+	name="Collapsible Initially Collapsed"
+	args={{
+		title: 'Initially Collapsed',
+		description: 'This section starts collapsed',
+		collapsible: true,
+		collapsed: true,
+		content: 'This content was hidden initially but is now visible.'
+	}}
+/>
+
+<!-- State Stories -->
+<Story
+	name="Disabled"
+	args={{
+		title: 'Disabled Section',
+		disabled: true,
+		content: 'This section is disabled and cannot be interacted with.'
+	}}
+/>
+
+<Story
+	name="Loading"
+	args={{
+		title: 'Loading Section',
+		loading: true,
+		content: 'This content is loading...'
+	}}
+/>
+
+<Story
+	name="With Divider"
+	args={{
+		title: 'Section with Divider',
+		divider: true,
+		content: 'This section has a divider at the bottom.'
+	}}
+/>
+
+<!-- With Icon -->
+<Story
+	name="With Icon"
+	args={{
+		title: 'Section with Icon',
+		description: 'This section displays an icon',
+		showIcon: true,
+		content: 'The icon is displayed before the title for visual emphasis.'
+	}}
+/>
+
+<!-- With Header Actions -->
+<Story
+	name="With Header Actions"
+	args={{
+		title: 'Section with Actions',
+		description: 'This section has action buttons',
+		showHeaderActions: true,
+		content: 'Header actions appear on the right side of the header.'
+	}}
+/>
+
+<!-- With Icon and Description -->
+<Story
+	name="With Icon and Description"
+	args={{
+		title: 'Complete Section',
+		description: 'A section with all header elements',
+		showIcon: true,
+		variant: 'bordered',
+		content: 'This section showcases all header elements together.'
+	}}
+/>
+
+<!-- Playground -->
+<Story
+	name="Playground"
+	args={{
+		title: 'Interactive Section',
+		description: 'Try changing the controls to see different states',
+		variant: 'bordered',
+		padding: 'md',
+		collapsible: false,
+		collapsed: false,
+		disabled: false,
+		loading: false,
+		divider: false,
+		showIcon: false,
+		showHeaderActions: false,
+		content:
+			'Use the Storybook controls to experiment with different props and see how the component responds.'
+	}}
+/>

--- a/hexawebshare/src/components/core/layout/CardSection.svelte
+++ b/hexawebshare/src/components/core/layout/CardSection.svelte
@@ -2,3 +2,263 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Props interface for the CardSection component
+	 * A card section groups related content within a card layout
+	 */
+	interface Props {
+		/**
+		 * Section title/heading
+		 */
+		title?: string;
+		/**
+		 * Section description text
+		 */
+		description?: string;
+		/**
+		 * Visual variant of the section
+		 * @default 'default'
+		 */
+		variant?: 'default' | 'bordered' | 'filled' | 'ghost';
+		/**
+		 * Padding size for the section
+		 * @default 'md'
+		 */
+		padding?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+		/**
+		 * Whether the section is collapsible
+		 * @default false
+		 */
+		collapsible?: boolean;
+		/**
+		 * Whether the section is initially collapsed (only applies if collapsible)
+		 * @default false
+		 */
+		collapsed?: boolean;
+		/**
+		 * Whether the section is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Whether the section is in loading state
+		 * @default false
+		 */
+		loading?: boolean;
+		/**
+		 * Whether to show a divider at the bottom
+		 * @default false
+		 */
+		divider?: boolean;
+		/**
+		 * Accessible label for screen readers
+		 */
+		ariaLabel?: string;
+		/**
+		 * Icon snippet to display before the title
+		 */
+		icon?: Snippet;
+		/**
+		 * Header actions snippet (buttons, links, etc.)
+		 */
+		headerActions?: Snippet;
+		/**
+		 * Main content snippet
+		 */
+		children?: Snippet;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		title,
+		description,
+		variant = 'default',
+		padding = 'md',
+		collapsible = false,
+		collapsed = false,
+		disabled = false,
+		loading = false,
+		divider = false,
+		ariaLabel,
+		icon,
+		headerActions,
+		children,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Internal collapsed state for collapsible sections
+	let isCollapsed = $state(collapsed);
+
+	// Toggle collapsed state
+	function toggleCollapsed() {
+		if (collapsible && !disabled) {
+			isCollapsed = !isCollapsed;
+		}
+	}
+
+	// Handle keyboard navigation for collapsible sections
+	function handleKeyDown(event: KeyboardEvent) {
+		if (collapsible && !disabled && (event.key === 'Enter' || event.key === ' ')) {
+			event.preventDefault();
+			toggleCollapsed();
+		}
+	}
+
+	// Section container classes using static DaisyUI/Tailwind classes
+	let sectionClasses = $derived(
+		[
+			'card-section',
+			variant === 'bordered' && 'border border-base-300 rounded-lg',
+			variant === 'filled' && 'bg-base-200 rounded-lg',
+			variant === 'ghost' && 'bg-transparent',
+			divider && 'border-b border-base-300',
+			disabled && 'opacity-50 pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Padding classes based on padding prop
+	let paddingClasses = $derived(
+		[
+			padding === 'none' && '',
+			padding === 'xs' && 'p-2',
+			padding === 'sm' && 'p-3',
+			padding === 'md' && 'p-4',
+			padding === 'lg' && 'p-6',
+			padding === 'xl' && 'p-8'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Header classes
+	let headerClasses = $derived(
+		[
+			'card-section-header',
+			'flex items-start justify-between gap-4',
+			(title || description || icon || headerActions) && 'mb-3',
+			collapsible && !disabled && 'cursor-pointer select-none'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Content wrapper classes
+	let contentClasses = $derived(
+		['card-section-content', collapsible && isCollapsed && 'hidden'].filter(Boolean).join(' ')
+	);
+
+	// Chevron rotation for collapsible
+	let chevronClasses = $derived(
+		[
+			'transition-transform duration-200',
+			'w-5 h-5 text-base-content/60',
+			!isCollapsed && 'rotate-180'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<section class="{sectionClasses} {paddingClasses}" aria-label={ariaLabel || title} {...props}>
+	{#if title || description || icon || headerActions || collapsible}
+		{#if collapsible}
+			<button
+				type="button"
+				class="{headerClasses} w-full border-0 bg-transparent text-left"
+				onclick={toggleCollapsed}
+				aria-expanded={!isCollapsed}
+				{disabled}
+			>
+				<div class="flex flex-1 items-start gap-3">
+					{#if icon}
+						<div class="card-section-icon flex-shrink-0" aria-hidden="true">
+							{@render icon()}
+						</div>
+					{/if}
+
+					<div class="flex-1">
+						{#if title}
+							<span class="card-section-title block text-base font-semibold text-base-content">
+								{title}
+							</span>
+						{/if}
+						{#if description}
+							<span class="card-section-description mt-1 block text-sm text-base-content/70">
+								{description}
+							</span>
+						{/if}
+					</div>
+				</div>
+
+				<div class="flex flex-shrink-0 items-center gap-2">
+					<svg
+						class={chevronClasses}
+						fill="none"
+						stroke="currentColor"
+						viewBox="0 0 24 24"
+						aria-hidden="true"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M19 9l-7 7-7-7"
+						/>
+					</svg>
+				</div>
+			</button>
+		{:else}
+			<div class={headerClasses}>
+				<div class="flex flex-1 items-start gap-3">
+					{#if icon}
+						<div class="card-section-icon flex-shrink-0" aria-hidden="true">
+							{@render icon()}
+						</div>
+					{/if}
+
+					<div class="flex-1">
+						{#if title}
+							<h3 class="card-section-title text-base font-semibold text-base-content">
+								{title}
+							</h3>
+						{/if}
+						{#if description}
+							<p class="card-section-description mt-1 text-sm text-base-content/70">
+								{description}
+							</p>
+						{/if}
+					</div>
+				</div>
+
+				<div class="flex flex-shrink-0 items-center gap-2">
+					{#if headerActions}
+						<div class="card-section-actions">
+							{@render headerActions()}
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	{/if}
+
+	<div class={contentClasses}>
+		{#if loading}
+			<div class="flex items-center justify-center py-8" aria-label="Loading content">
+				<span class="loading loading-spinner loading-md"></span>
+			</div>
+		{:else if children}
+			{@render children()}
+		{/if}
+	</div>
+</section>

--- a/hexawebshare/src/components/core/layout/CardSectionWrapper.svelte
+++ b/hexawebshare/src/components/core/layout/CardSectionWrapper.svelte
@@ -1,0 +1,140 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script lang="ts">
+	import CardSection from './CardSection.svelte';
+
+	interface Props {
+		title?: string;
+		description?: string;
+		variant?: 'default' | 'bordered' | 'filled' | 'ghost';
+		padding?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+		collapsible?: boolean;
+		collapsed?: boolean;
+		disabled?: boolean;
+		loading?: boolean;
+		divider?: boolean;
+		ariaLabel?: string;
+		content?: string;
+		showIcon?: boolean;
+		showHeaderActions?: boolean;
+		class?: string;
+	}
+
+	const {
+		title = 'Section Title',
+		description,
+		variant = 'default',
+		padding = 'md',
+		collapsible = false,
+		collapsed = false,
+		disabled = false,
+		loading = false,
+		divider = false,
+		ariaLabel,
+		content = 'This is the card section content. It can contain any type of content including text, forms, or other components.',
+		showIcon = false,
+		showHeaderActions = false,
+		class: className = ''
+	}: Props = $props();
+</script>
+
+<div class="min-h-[200px] bg-base-300 p-6">
+	<div class="card mx-auto max-w-2xl bg-base-100 shadow-xl">
+		<div class="card-body p-0">
+			{#if showIcon && showHeaderActions}
+				<CardSection
+					{title}
+					{description}
+					{variant}
+					{padding}
+					{collapsible}
+					{collapsed}
+					{disabled}
+					{loading}
+					{divider}
+					{ariaLabel}
+					class={className}
+				>
+					{#snippet icon()}
+						<svg class="h-6 w-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+					{/snippet}
+					{#snippet headerActions()}
+						<button class="btn btn-primary btn-sm">Action</button>
+					{/snippet}
+					<p class="text-base-content/70">{content}</p>
+				</CardSection>
+			{:else if showIcon}
+				<CardSection
+					{title}
+					{description}
+					{variant}
+					{padding}
+					{collapsible}
+					{collapsed}
+					{disabled}
+					{loading}
+					{divider}
+					{ariaLabel}
+					class={className}
+				>
+					{#snippet icon()}
+						<svg class="h-6 w-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+					{/snippet}
+					<p class="text-base-content/70">{content}</p>
+				</CardSection>
+			{:else if showHeaderActions}
+				<CardSection
+					{title}
+					{description}
+					{variant}
+					{padding}
+					{collapsible}
+					{collapsed}
+					{disabled}
+					{loading}
+					{divider}
+					{ariaLabel}
+					class={className}
+				>
+					{#snippet headerActions()}
+						<button class="btn btn-primary btn-sm">Action</button>
+					{/snippet}
+					<p class="text-base-content/70">{content}</p>
+				</CardSection>
+			{:else}
+				<CardSection
+					{title}
+					{description}
+					{variant}
+					{padding}
+					{collapsible}
+					{collapsed}
+					{disabled}
+					{loading}
+					{divider}
+					{ariaLabel}
+					class={className}
+				>
+					<p class="text-base-content/70">{content}</p>
+				</CardSection>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/hexawebshare/src/lib/index.ts
+++ b/hexawebshare/src/lib/index.ts
@@ -2,12 +2,3 @@
 // SPDX-License-Identifier: MIT
 
 // Reexport your entry components here
-
-export { default as ButtonGroup } from '../components/core/buttons/ButtonGroup.svelte';
-
-// Core - Feedback
-export { default as Spinner } from '../components/core/feedback/Spinner.svelte';
-export { default as Loader } from '../components/core/feedback/Loader.svelte';
-
-// Core - Overlay Navigation
-export { default as Dialog } from '../components/core/overlay-navigation/Dialog.svelte';


### PR DESCRIPTION
# Pull Request

## 📄 Summary

> Implements the **CardSection** component as requested in issue #95.
>
> The `CardSection` component provides a reusable section container for grouping related content within cards. It follows Svelte 5 patterns with runes (`$props`, `$derived`, `$state`) and uses DaisyUI classes statically (no dynamic string interpolation).
>
> **Features implemented:**
>
> - TypeScript Props interface with full JSDoc documentation
> - Visual variants: `default`, `bordered`, `filled`, `ghost`
> - Padding sizes: `none`, `xs`, `sm`, `md`, `lg`, `xl`
> - Collapsible sections with keyboard navigation (Enter/Space)
> - Icon and header actions snippets support
> - Loading, disabled states
> - Bottom divider option for stacking sections
> - Full accessibility (ARIA labels, roles, keyboard support)
> - Comprehensive Storybook stories

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

> ⚠️ PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format.  
> **Only these types are allowed:**

```text
feat, fix, chore, refactor, test, docs, ci, perf, build, release, hotfix, style
```

✅ PR Title:

```text
feat(CardSection): implement CardSection component with Storybook stories
```

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: `<type>/<short-description>` (feat/add-card-section-component)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (`pnpm format`)
- [x] I ran static analysis (`pnpm check`) and resolved warnings
- [x] I ran tests successfully (`pnpm test`)
- [x] I updated / checked package.json for dependency changes
- [x] For UI changes, I added Storybook stories
- [x] I linked related issues using keywords like `Closes #95`
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

#95
