### PR TITLE
feat(ListItem): add list item component with comprehensive stories

### DIFF
--- a/hexawebshare/src/components/core/data-display/ListItem.stories.svelte
+++ b/hexawebshare/src/components/core/data-display/ListItem.stories.svelte
@@ -1,0 +1,676 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import ListItem from './ListItem.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Data Display/ListItem',
+		component: ListItem,
+		tags: ['autodocs'],
+		argTypes: {
+			label: {
+				control: 'text',
+				description: 'Primary text content of the list item'
+			},
+			description: {
+				control: 'text',
+				description: 'Secondary/description text displayed below the label'
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'primary',
+					'secondary',
+					'accent',
+					'neutral',
+					'info',
+					'success',
+					'warning',
+					'error'
+				],
+				description: 'Color variant of the list item when active'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['sm', 'md', 'lg'],
+				description: 'Size of the list item'
+			},
+			active: {
+				control: 'boolean',
+				description: 'Whether the list item is currently active/selected'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Whether the list item is disabled'
+			},
+			loading: {
+				control: 'boolean',
+				description: 'Whether the list item is in loading state'
+			},
+			hoverable: {
+				control: 'boolean',
+				description: 'Whether the list item shows hover effect'
+			},
+			bordered: {
+				control: 'boolean',
+				description: 'Whether the list item has a border at the bottom'
+			},
+			href: {
+				control: 'text',
+				description: 'URL to navigate to (makes the item a link)'
+			},
+			target: {
+				control: { type: 'select' },
+				options: ['_blank', '_self', '_parent', '_top'],
+				description: 'Target for the link'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for screen readers'
+			},
+			selected: {
+				control: 'boolean',
+				description: 'Whether the item is currently selected (for aria-selected)'
+			}
+		},
+		args: {
+			label: 'List Item',
+			size: 'md',
+			variant: 'neutral',
+			hoverable: true
+		}
+	});
+</script>
+
+<script lang="ts">
+	let selectedIndex = $state(0);
+
+	function handleClick(index: number) {
+		selectedIndex = index;
+	}
+</script>
+
+<!-- Default Story -->
+<Story name="Default" args={{ label: 'Default List Item', size: 'md', variant: 'neutral' }} />
+
+<!-- With Description -->
+<Story
+	name="With Description"
+	args={{
+		label: 'List Item with Description',
+		description: 'This is a secondary description text that provides more context',
+		size: 'md',
+		variant: 'neutral'
+	}}
+/>
+
+<!-- Size Stories -->
+<Story
+	name="Small"
+	args={{
+		label: 'Small Item',
+		description: 'Compact size for dense lists',
+		size: 'sm'
+	}}
+/>
+<Story
+	name="Medium"
+	args={{
+		label: 'Medium Item',
+		description: 'Default size for most use cases',
+		size: 'md'
+	}}
+/>
+<Story
+	name="Large"
+	args={{
+		label: 'Large Item',
+		description: 'Larger size for prominent items',
+		size: 'lg'
+	}}
+/>
+
+<!-- Active Variant Stories -->
+<Story name="Active Primary" args={{ label: 'Active Primary', variant: 'primary', active: true }} />
+<Story
+	name="Active Secondary"
+	args={{ label: 'Active Secondary', variant: 'secondary', active: true }}
+/>
+<Story name="Active Accent" args={{ label: 'Active Accent', variant: 'accent', active: true }} />
+<Story name="Active Neutral" args={{ label: 'Active Neutral', variant: 'neutral', active: true }} />
+<Story name="Active Info" args={{ label: 'Active Info', variant: 'info', active: true }} />
+<Story name="Active Success" args={{ label: 'Active Success', variant: 'success', active: true }} />
+<Story name="Active Warning" args={{ label: 'Active Warning', variant: 'warning', active: true }} />
+<Story name="Active Error" args={{ label: 'Active Error', variant: 'error', active: true }} />
+
+<!-- State Stories -->
+<Story
+	name="Disabled"
+	args={{
+		label: 'Disabled Item',
+		description: 'This item is disabled',
+		disabled: true
+	}}
+/>
+<Story
+	name="Loading"
+	args={{
+		label: 'Loading Item',
+		description: 'Loading state with spinner',
+		loading: true
+	}}
+/>
+<Story
+	name="Non-Hoverable"
+	args={{
+		label: 'Non-Hoverable Item',
+		description: 'No hover effect',
+		hoverable: false
+	}}
+/>
+<Story
+	name="Bordered"
+	args={{
+		label: 'Bordered Item',
+		description: 'Has a bottom border',
+		bordered: true
+	}}
+/>
+
+<!-- Link Stories -->
+<Story
+	name="As Link"
+	args={{
+		label: 'Link Item',
+		description: 'Click to navigate',
+		href: '#example-link'
+	}}
+/>
+<Story
+	name="External Link"
+	args={{
+		label: 'External Link',
+		description: 'Opens in new tab',
+		href: 'https://example.com',
+		target: '_blank'
+	}}
+/>
+
+<!-- Accessibility Stories -->
+<Story
+	name="With Aria Label"
+	args={{
+		label: 'List Item',
+		ariaLabel: 'Accessible list item with custom aria label'
+	}}
+/>
+<Story
+	name="Selected State"
+	args={{
+		label: 'Selected Item',
+		selected: true,
+		active: true,
+		variant: 'primary'
+	}}
+/>
+
+<!-- All Sizes Showcase -->
+<Story name="All Sizes">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="Small Item" description="Compact size" size="sm" bordered={true} />
+		<ListItem label="Medium Item" description="Default size" size="md" bordered={true} />
+		<ListItem label="Large Item" description="Prominent size" size="lg" />
+	</div>
+</Story>
+
+<!-- All Active Variants Showcase -->
+<Story name="All Active Variants">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="Primary" variant="primary" active={true} bordered={true} />
+		<ListItem label="Secondary" variant="secondary" active={true} bordered={true} />
+		<ListItem label="Accent" variant="accent" active={true} bordered={true} />
+		<ListItem label="Neutral" variant="neutral" active={true} bordered={true} />
+		<ListItem label="Info" variant="info" active={true} bordered={true} />
+		<ListItem label="Success" variant="success" active={true} bordered={true} />
+		<ListItem label="Warning" variant="warning" active={true} bordered={true} />
+		<ListItem label="Error" variant="error" active={true} />
+	</div>
+</Story>
+
+<!-- With Leading Icon -->
+<Story name="With Leading Icon">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="Home" description="Go to dashboard" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Settings" description="Manage preferences" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+					/>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Profile" description="View your profile">
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+	</div>
+</Story>
+
+<!-- With Trailing Content -->
+<Story name="With Trailing Badge">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="Notifications" description="View all notifications" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+					/>
+				</svg>
+			{/snippet}
+			{#snippet trailing()}
+				<span class="badge badge-primary badge-sm">5</span>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Messages" description="Read your messages" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+					/>
+				</svg>
+			{/snippet}
+			{#snippet trailing()}
+				<span class="badge badge-error badge-sm">12</span>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Updates" description="Software updates available">
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+					/>
+				</svg>
+			{/snippet}
+			{#snippet trailing()}
+				<span class="badge badge-success badge-sm">New</span>
+			{/snippet}
+		</ListItem>
+	</div>
+</Story>
+
+<!-- With Trailing Action -->
+<Story name="With Trailing Action">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="John Doe" description="john.doe@example.com" bordered={true}>
+			{#snippet leading()}
+				<div class="avatar placeholder">
+					<div class="w-10 rounded-full bg-neutral text-neutral-content">
+						<span class="text-sm">JD</span>
+					</div>
+				</div>
+			{/snippet}
+			{#snippet trailing()}
+				<button class="btn btn-circle btn-ghost btn-sm" aria-label="More options for John Doe">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-5 w-5"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+						/>
+					</svg>
+				</button>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Jane Smith" description="jane.smith@example.com" bordered={true}>
+			{#snippet leading()}
+				<div class="avatar placeholder">
+					<div class="w-10 rounded-full bg-primary text-primary-content">
+						<span class="text-sm">JS</span>
+					</div>
+				</div>
+			{/snippet}
+			{#snippet trailing()}
+				<button class="btn btn-circle btn-ghost btn-sm" aria-label="More options for Jane Smith">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-5 w-5"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+						/>
+					</svg>
+				</button>
+			{/snippet}
+		</ListItem>
+	</div>
+</Story>
+
+<!-- Interactive Selection Example -->
+<Story name="Interactive Selection">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<p class="px-4 py-2 text-sm text-base-content/70">Click to select an item:</p>
+		<ListItem
+			label="Option 1"
+			description="First option"
+			active={selectedIndex === 0}
+			variant="primary"
+			bordered={true}
+			onclick={() => handleClick(0)}
+		/>
+		<ListItem
+			label="Option 2"
+			description="Second option"
+			active={selectedIndex === 1}
+			variant="primary"
+			bordered={true}
+			onclick={() => handleClick(1)}
+		/>
+		<ListItem
+			label="Option 3"
+			description="Third option"
+			active={selectedIndex === 2}
+			variant="primary"
+			onclick={() => handleClick(2)}
+		/>
+	</div>
+</Story>
+
+<!-- Loading States -->
+<Story name="Loading States">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="Loading..." loading={true} bordered={true} />
+		<ListItem
+			label="Loading with description"
+			description="Please wait..."
+			loading={true}
+			bordered={true}
+		/>
+		<ListItem label="Normal Item" description="Not loading" bordered={true} />
+	</div>
+</Story>
+
+<!-- Disabled States -->
+<Story name="Disabled States">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="Enabled Item" description="Click me" bordered={true} />
+		<ListItem label="Disabled Item" description="Cannot interact" disabled={true} bordered={true} />
+		<ListItem label="Disabled with Icon" description="Also disabled" disabled={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+	</div>
+</Story>
+
+<!-- Navigation Menu Example -->
+<Story name="Navigation Menu">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="Dashboard" href="#dashboard" variant="primary" active={true} bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Analytics" href="#analytics" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Users" href="#users" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+		<ListItem label="Settings" href="#settings">
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-5 w-5"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+					/>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+					/>
+				</svg>
+			{/snippet}
+		</ListItem>
+	</div>
+</Story>
+
+<!-- File List Example -->
+<Story name="File List Example">
+	<div class="w-full max-w-md rounded-lg bg-base-100 shadow">
+		<ListItem label="document.pdf" description="2.4 MB • Modified today" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-8 w-8 text-error"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+					/>
+				</svg>
+			{/snippet}
+			{#snippet trailing()}
+				<button class="btn btn-ghost btn-sm">Download</button>
+			{/snippet}
+		</ListItem>
+		<ListItem label="image.png" description="1.2 MB • Modified yesterday" bordered={true}>
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-8 w-8 text-success"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+					/>
+				</svg>
+			{/snippet}
+			{#snippet trailing()}
+				<button class="btn btn-ghost btn-sm">Download</button>
+			{/snippet}
+		</ListItem>
+		<ListItem label="spreadsheet.xlsx" description="856 KB • Modified last week">
+			{#snippet leading()}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					class="h-8 w-8 text-info"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+					/>
+				</svg>
+			{/snippet}
+			{#snippet trailing()}
+				<button class="btn btn-ghost btn-sm">Download</button>
+			{/snippet}
+		</ListItem>
+	</div>
+</Story>
+
+<!-- Playground -->
+<Story
+	name="Playground"
+	args={{
+		label: 'Configurable List Item',
+		description: 'Use the controls to customize',
+		size: 'md',
+		variant: 'neutral',
+		hoverable: true,
+		bordered: false,
+		active: false,
+		disabled: false,
+		loading: false
+	}}
+/>

--- a/hexawebshare/src/components/core/data-display/ListItem.svelte
+++ b/hexawebshare/src/components/core/data-display/ListItem.svelte
@@ -2,3 +2,288 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Props interface for the ListItem component
+	 */
+	interface Props {
+		/**
+		 * Primary text content of the list item
+		 */
+		label: string;
+		/**
+		 * Secondary/description text displayed below the label
+		 */
+		description?: string;
+		/**
+		 * Color variant of the list item when active or focused
+		 * @default 'neutral'
+		 */
+		variant?:
+			| 'primary'
+			| 'secondary'
+			| 'accent'
+			| 'neutral'
+			| 'info'
+			| 'success'
+			| 'warning'
+			| 'error';
+		/**
+		 * Size of the list item
+		 * @default 'md'
+		 */
+		size?: 'sm' | 'md' | 'lg';
+		/**
+		 * Whether the list item is currently active/selected
+		 * @default false
+		 */
+		active?: boolean;
+		/**
+		 * Whether the list item is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Whether the list item is in loading state
+		 * @default false
+		 */
+		loading?: boolean;
+		/**
+		 * Whether the list item shows hover effect
+		 * @default true
+		 */
+		hoverable?: boolean;
+		/**
+		 * Whether the list item has a border at the bottom
+		 * @default false
+		 */
+		bordered?: boolean;
+		/**
+		 * Click handler for the list item
+		 */
+		onclick?: (event: MouseEvent) => void;
+		/**
+		 * Keyboard handler for the list item
+		 */
+		onkeydown?: (event: KeyboardEvent) => void;
+		/**
+		 * URL to navigate to (makes the item a link)
+		 */
+		href?: string;
+		/**
+		 * Target for the link
+		 */
+		target?: '_blank' | '_self' | '_parent' | '_top';
+		/**
+		 * Accessible label for screen readers
+		 */
+		ariaLabel?: string;
+		/**
+		 * Whether the item is currently selected (for aria-selected)
+		 */
+		selected?: boolean;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+		/**
+		 * Slot for leading content (icon, avatar, checkbox, etc.)
+		 */
+		leading?: Snippet;
+		/**
+		 * Slot for trailing content (badge, action buttons, etc.)
+		 */
+		trailing?: Snippet;
+		/**
+		 * Slot for custom content (replaces label and description)
+		 */
+		children?: Snippet;
+	}
+
+	const {
+		label,
+		description,
+		variant = 'neutral',
+		size = 'md',
+		active = false,
+		disabled = false,
+		loading = false,
+		hoverable = true,
+		bordered = false,
+		onclick,
+		onkeydown,
+		href,
+		target,
+		ariaLabel,
+		selected,
+		class: className = '',
+		leading,
+		trailing,
+		children,
+		...props
+	}: Props = $props();
+
+	// Base classes for the list item container
+	let containerClasses = $derived(
+		[
+			'flex items-center gap-3 w-full transition-colors duration-200',
+			// Size classes
+			size === 'sm' && 'px-3 py-2 text-sm',
+			size === 'md' && 'px-4 py-3 text-base',
+			size === 'lg' && 'px-5 py-4 text-lg',
+			// Hover effect
+			hoverable && !disabled && 'hover:bg-base-200 cursor-pointer',
+			// Active/selected state using static classes
+			active && variant === 'primary' && 'bg-primary text-primary-content',
+			active && variant === 'secondary' && 'bg-secondary text-secondary-content',
+			active && variant === 'accent' && 'bg-accent text-accent-content',
+			active && variant === 'neutral' && 'bg-neutral text-neutral-content',
+			active && variant === 'info' && 'bg-info text-info-content',
+			active && variant === 'success' && 'bg-success text-success-content',
+			active && variant === 'warning' && 'bg-warning text-warning-content',
+			active && variant === 'error' && 'bg-error text-error-content',
+			// Disabled state
+			disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+			// Border
+			bordered && 'border-b border-base-300',
+			// Focus visible
+			!disabled && 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+			// Custom classes
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Text content classes
+	let labelClasses = $derived(
+		['font-medium truncate', loading && 'skeleton w-32 h-4', disabled && 'text-base-content/50']
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	let descriptionClasses = $derived(
+		[
+			'text-sm truncate',
+			active ? 'opacity-80' : 'text-base-content/70',
+			loading && 'skeleton w-48 h-3 mt-1',
+			disabled && 'text-base-content/40'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Loading spinner size based on item size
+	let spinnerSizeClass = $derived(
+		size === 'sm' ? 'loading-xs' : size === 'md' ? 'loading-sm' : 'loading-md'
+	);
+
+	// Determine if the item is interactive
+	let isInteractive = $derived(!!onclick || !!href || !!onkeydown);
+
+	// Handle keyboard navigation
+	function handleKeydown(event: KeyboardEvent) {
+		if (disabled) return;
+
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			if (onclick) {
+				onclick(event as unknown as MouseEvent);
+			}
+		}
+
+		if (onkeydown) {
+			onkeydown(event);
+		}
+	}
+
+	// Handle click
+	function handleClick(event: MouseEvent) {
+		if (disabled) return;
+		if (onclick) {
+			onclick(event);
+		}
+	}
+</script>
+
+{#if href && !disabled}
+	<!-- Link variant -->
+	<a
+		{href}
+		{target}
+		class={containerClasses}
+		aria-label={ariaLabel || label}
+		aria-disabled={disabled}
+		aria-current={active ? 'true' : undefined}
+		rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+		{...props}
+	>
+		{#if loading}
+			<span class="loading loading-spinner {spinnerSizeClass}" aria-hidden="true"></span>
+		{:else if leading}
+			<span class="flex-shrink-0" aria-hidden="true">
+				{@render leading()}
+			</span>
+		{/if}
+
+		<span class="min-w-0 flex-1">
+			{#if children}
+				{@render children()}
+			{:else}
+				<span class={labelClasses}>{label}</span>
+				{#if description}
+					<span class={descriptionClasses}>{description}</span>
+				{/if}
+			{/if}
+		</span>
+
+		{#if trailing}
+			<span class="flex-shrink-0" aria-hidden="true">
+				{@render trailing()}
+			</span>
+		{/if}
+	</a>
+{:else}
+	<!-- Button/div variant -->
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+	<div
+		class={containerClasses}
+		role={isInteractive ? 'button' : selected !== undefined ? 'option' : 'listitem'}
+		tabindex={isInteractive && !disabled ? 0 : undefined}
+		aria-label={ariaLabel || label}
+		aria-disabled={disabled}
+		aria-selected={selected}
+		aria-current={active ? 'true' : undefined}
+		onclick={handleClick}
+		onkeydown={handleKeydown}
+		{...props}
+	>
+		{#if loading}
+			<span class="loading loading-spinner {spinnerSizeClass}" aria-hidden="true"></span>
+		{:else if leading}
+			<span class="flex-shrink-0" aria-hidden="true">
+				{@render leading()}
+			</span>
+		{/if}
+
+		<span class="flex min-w-0 flex-1 flex-col">
+			{#if children}
+				{@render children()}
+			{:else}
+				<span class={labelClasses}>{label}</span>
+				{#if description}
+					<span class={descriptionClasses}>{description}</span>
+				{/if}
+			{/if}
+		</span>
+
+		{#if trailing}
+			<span class="flex-shrink-0">
+				{@render trailing()}
+			</span>
+		{/if}
+	</div>
+{/if}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR adds a fully functional ListItem component to the core/data-display module. The component follows Svelte 5 patterns with runes and includes comprehensive Storybook documentation.

**Key features:**
- TypeScript Props interface with full JSDoc documentation
- Size variants (sm, md, lg)
- Color variants for active state (primary, secondary, accent, neutral, info, success, warning, error)
- State support (active, disabled, loading, hoverable, bordered, selected)
- Navigation support with href links
- Snippet slots for leading/trailing content (icons, badges, action buttons)
- Full accessibility support (ARIA attributes, keyboard navigation, focus management)

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

✅ Using: `feat(ListItem): add list item component with comprehensive Storybook stories`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/add-listitem-component)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis and resolved warnings
- [x] I ran tests successfully (pnpm check)
- [ ] I updated / checked pubspec.yaml and pubspec.lock for dependency changes (N/A - Svelte project)
- [x] For UI changes, I added screenshots and/or updated Storybook stories
- [x] I linked related issues using keywords like Closes #91 
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

> If this PR addresses one or more issues, link them here:

Closes #91 
