### PR TITLE
feat(core): add empty state component with DaisyUI styling

### DIFF
--- a/hexawebshare/src/components/core/data-display/EmptyState.stories.svelte
+++ b/hexawebshare/src/components/core/data-display/EmptyState.stories.svelte
@@ -1,0 +1,295 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import EmptyState from './EmptyState.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Data Display/EmptyState',
+		component: EmptyState,
+		tags: ['autodocs'],
+		argTypes: {
+			title: {
+				control: 'text',
+				description: 'Main heading text displayed prominently'
+			},
+			description: {
+				control: 'text',
+				description: 'Supporting description text below the title'
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'primary',
+					'secondary',
+					'accent',
+					'neutral',
+					'info',
+					'success',
+					'warning',
+					'error'
+				],
+				description: 'Visual variant affecting icon and accent colors'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['sm', 'md', 'lg'],
+				description: 'Size preset affecting spacing and typography'
+			},
+			loading: {
+				control: 'boolean',
+				description: 'Whether the component is in loading state'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Whether the component is disabled'
+			},
+			bordered: {
+				control: 'boolean',
+				description: 'Add a bordered card-like appearance'
+			},
+			filled: {
+				control: 'boolean',
+				description: 'Add a subtle background color'
+			},
+			fullWidth: {
+				control: 'boolean',
+				description: 'Make the container full width'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for screen readers'
+			}
+		},
+		args: {
+			title: 'No items found',
+			description: 'There are no items to display at the moment.',
+			variant: 'neutral',
+			size: 'md',
+			loading: false,
+			disabled: false,
+			bordered: false,
+			filled: false,
+			fullWidth: true
+		}
+	});
+</script>
+
+<!-- Default Story -->
+<Story
+	name="Default"
+	args={{
+		title: 'No items found',
+		description: 'There are no items to display at the moment.'
+	}}
+/>
+
+<!-- Size Stories -->
+<Story
+	name="Small"
+	args={{
+		title: 'No results',
+		description: 'Try adjusting your search criteria.',
+		size: 'sm'
+	}}
+/>
+
+<Story
+	name="Medium"
+	args={{
+		title: 'No items found',
+		description: 'There are no items to display at the moment.',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Large"
+	args={{
+		title: 'Welcome to your dashboard',
+		description:
+			"It looks like you haven't added any items yet. Get started by creating your first item.",
+		size: 'lg'
+	}}
+/>
+
+<!-- Variant Stories -->
+<Story
+	name="Primary"
+	args={{
+		title: 'Get started',
+		description: 'Create your first project to begin.',
+		variant: 'primary'
+	}}
+/>
+
+<Story
+	name="Secondary"
+	args={{
+		title: 'No notifications',
+		description: "You're all caught up!",
+		variant: 'secondary'
+	}}
+/>
+
+<Story
+	name="Accent"
+	args={{
+		title: 'Discover something new',
+		description: 'Browse our collection to find what you need.',
+		variant: 'accent'
+	}}
+/>
+
+<Story
+	name="Neutral"
+	args={{
+		title: 'Nothing here yet',
+		description: 'This section is empty.',
+		variant: 'neutral'
+	}}
+/>
+
+<Story
+	name="Info"
+	args={{
+		title: 'No data available',
+		description: 'Data will appear here once available.',
+		variant: 'info'
+	}}
+/>
+
+<Story
+	name="Success"
+	args={{
+		title: 'All tasks completed',
+		description: 'Great job! You have completed all your tasks.',
+		variant: 'success'
+	}}
+/>
+
+<Story
+	name="Warning"
+	args={{
+		title: 'Action required',
+		description: 'Please complete the required steps to continue.',
+		variant: 'warning'
+	}}
+/>
+
+<Story
+	name="Error"
+	args={{
+		title: 'Something went wrong',
+		description: 'We encountered an error while loading your data.',
+		variant: 'error'
+	}}
+/>
+
+<!-- State Stories -->
+<Story
+	name="Loading"
+	args={{
+		title: 'Loading items',
+		description: 'Please wait while we fetch your data.',
+		loading: true
+	}}
+/>
+
+<Story
+	name="Disabled"
+	args={{
+		title: 'Feature unavailable',
+		description: 'This feature is currently disabled.',
+		disabled: true
+	}}
+/>
+
+<!-- Style Variants -->
+<Story
+	name="Bordered"
+	args={{
+		title: 'No messages',
+		description: 'Your inbox is empty.',
+		bordered: true
+	}}
+/>
+
+<Story
+	name="Filled"
+	args={{
+		title: 'No recent activity',
+		description: 'Activity will appear here.',
+		filled: true
+	}}
+/>
+
+<Story
+	name="Bordered and Filled"
+	args={{
+		title: 'Empty collection',
+		description: 'Add items to your collection to see them here.',
+		bordered: true,
+		filled: true
+	}}
+/>
+
+<!-- All Sizes Showcase -->
+<Story name="All Sizes">
+	<div class="space-y-8">
+		<EmptyState title="Small Size" description="Compact empty state for tight spaces." size="sm" />
+		<EmptyState title="Medium Size" description="Default size for most use cases." size="md" />
+		<EmptyState
+			title="Large Size"
+			description="Prominent empty state for main content areas."
+			size="lg"
+		/>
+	</div>
+</Story>
+
+<!-- All Variants Showcase -->
+<Story name="All Variants">
+	<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+		<EmptyState title="Primary" description="Primary variant" variant="primary" bordered={true} />
+		<EmptyState
+			title="Secondary"
+			description="Secondary variant"
+			variant="secondary"
+			bordered={true}
+		/>
+		<EmptyState title="Accent" description="Accent variant" variant="accent" bordered={true} />
+		<EmptyState title="Neutral" description="Neutral variant" variant="neutral" bordered={true} />
+		<EmptyState title="Info" description="Info variant" variant="info" bordered={true} />
+		<EmptyState title="Success" description="Success variant" variant="success" bordered={true} />
+		<EmptyState title="Warning" description="Warning variant" variant="warning" bordered={true} />
+		<EmptyState title="Error" description="Error variant" variant="error" bordered={true} />
+	</div>
+</Story>
+
+<!-- Accessibility Stories -->
+<Story
+	name="With Aria Label"
+	args={{
+		title: 'No items',
+		description: 'Empty state description',
+		ariaLabel: 'Empty state: No items available in this section'
+	}}
+/>
+
+<!-- Interactive Playground -->
+<Story
+	name="Playground"
+	args={{
+		title: 'Empty State',
+		description: 'Use the controls to customize this component.',
+		variant: 'neutral',
+		size: 'md',
+		bordered: false,
+		filled: false,
+		loading: false,
+		disabled: false
+	}}
+/>

--- a/hexawebshare/src/components/core/data-display/EmptyState.svelte
+++ b/hexawebshare/src/components/core/data-display/EmptyState.svelte
@@ -2,3 +2,313 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Props interface for the EmptyState component
+	 */
+	interface Props {
+		/**
+		 * Main heading text displayed prominently
+		 */
+		title?: string;
+		/**
+		 * Supporting description text below the title
+		 */
+		description?: string;
+		/**
+		 * Custom icon snippet rendered above the title
+		 */
+		icon?: Snippet;
+		/**
+		 * Custom content snippet rendered below the description
+		 */
+		children?: Snippet;
+		/**
+		 * Action buttons or links snippet
+		 */
+		actions?: Snippet;
+		/**
+		 * Visual variant affecting icon and accent colors
+		 * @default 'neutral'
+		 */
+		variant?:
+			| 'primary'
+			| 'secondary'
+			| 'accent'
+			| 'neutral'
+			| 'info'
+			| 'success'
+			| 'warning'
+			| 'error';
+		/**
+		 * Size preset affecting spacing and typography
+		 * @default 'md'
+		 */
+		size?: 'sm' | 'md' | 'lg';
+		/**
+		 * Whether the component is in loading state
+		 * @default false
+		 */
+		loading?: boolean;
+		/**
+		 * Whether the component is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Add a bordered card-like appearance
+		 * @default false
+		 */
+		bordered?: boolean;
+		/**
+		 * Add a subtle background color
+		 * @default false
+		 */
+		filled?: boolean;
+		/**
+		 * Make the container full width
+		 * @default true
+		 */
+		fullWidth?: boolean;
+		/**
+		 * Accessible label for screen readers
+		 */
+		ariaLabel?: string;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		title,
+		description,
+		icon,
+		children,
+		actions,
+		variant = 'neutral',
+		size = 'md',
+		loading = false,
+		disabled = false,
+		bordered = false,
+		filled = false,
+		fullWidth = true,
+		ariaLabel,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Generate unique IDs for accessibility
+	const baseId = crypto.randomUUID?.() ?? `empty-state-${Math.random().toString(36).slice(2, 9)}`;
+	const titleId = `${baseId}-title`;
+	const descriptionId = `${baseId}-description`;
+
+	// Determine if we have labelling elements
+	const hasTitle = $derived(!!title);
+	const hasDescription = $derived(!!description);
+
+	// Container classes using static DaisyUI classes
+	let containerClasses = $derived(
+		[
+			'flex',
+			'flex-col',
+			'items-center',
+			'justify-center',
+			'text-center',
+			fullWidth ? 'w-full' : 'w-fit',
+			// Size-based padding
+			size === 'sm' && 'px-4 py-6',
+			size === 'md' && 'px-6 py-10',
+			size === 'lg' && 'px-8 py-14',
+			// Bordered style
+			bordered && 'border border-base-300 rounded-xl',
+			// Filled background
+			filled && 'bg-base-200',
+			filled && bordered && 'bg-base-200',
+			// Disabled state
+			disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Icon container classes
+	let iconContainerClasses = $derived(
+		[
+			'flex',
+			'items-center',
+			'justify-center',
+			'rounded-full',
+			// Size-based icon container sizing
+			size === 'sm' && 'h-12 w-12',
+			size === 'md' && 'h-16 w-16',
+			size === 'lg' && 'h-20 w-20',
+			// Variant-based background colors
+			variant === 'primary' && 'bg-primary/10',
+			variant === 'secondary' && 'bg-secondary/10',
+			variant === 'accent' && 'bg-accent/10',
+			variant === 'neutral' && 'bg-base-300',
+			variant === 'info' && 'bg-info/10',
+			variant === 'success' && 'bg-success/10',
+			variant === 'warning' && 'bg-warning/10',
+			variant === 'error' && 'bg-error/10',
+			// Size-based margin
+			size === 'sm' && 'mb-3',
+			size === 'md' && 'mb-4',
+			size === 'lg' && 'mb-6'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Default icon classes (when no custom icon provided)
+	let defaultIconClasses = $derived(
+		[
+			// Size-based icon sizing
+			size === 'sm' && 'h-6 w-6',
+			size === 'md' && 'h-8 w-8',
+			size === 'lg' && 'h-10 w-10',
+			// Variant-based icon colors
+			variant === 'primary' && 'text-primary',
+			variant === 'secondary' && 'text-secondary',
+			variant === 'accent' && 'text-accent',
+			variant === 'neutral' && 'text-base-content/60',
+			variant === 'info' && 'text-info',
+			variant === 'success' && 'text-success',
+			variant === 'warning' && 'text-warning',
+			variant === 'error' && 'text-error'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Title classes
+	let titleClasses = $derived(
+		[
+			'font-semibold',
+			'text-base-content',
+			// Size-based typography
+			size === 'sm' && 'text-base',
+			size === 'md' && 'text-lg',
+			size === 'lg' && 'text-xl',
+			// Size-based margin
+			hasDescription && size === 'sm' && 'mb-1',
+			hasDescription && size === 'md' && 'mb-2',
+			hasDescription && size === 'lg' && 'mb-3'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Description classes
+	let descriptionClasses = $derived(
+		[
+			'text-base-content/70',
+			'max-w-md',
+			// Size-based typography
+			size === 'sm' && 'text-sm',
+			size === 'md' && 'text-base',
+			size === 'lg' && 'text-lg'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Actions container classes
+	let actionsClasses = $derived(
+		[
+			'flex',
+			'flex-wrap',
+			'items-center',
+			'justify-center',
+			'gap-3',
+			// Size-based margin
+			size === 'sm' && 'mt-4',
+			size === 'md' && 'mt-6',
+			size === 'lg' && 'mt-8'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Loading spinner size class
+	let spinnerSizeClass = $derived(
+		size === 'sm' ? 'loading-md' : size === 'md' ? 'loading-lg' : 'loading-lg'
+	);
+</script>
+
+<div
+	class={containerClasses}
+	role="status"
+	aria-label={ariaLabel}
+	aria-labelledby={hasTitle ? titleId : undefined}
+	aria-describedby={hasDescription ? descriptionId : undefined}
+	aria-busy={loading}
+	{...props}
+>
+	{#if loading}
+		<!-- Loading State -->
+		<div class="flex flex-col items-center justify-center gap-4">
+			<span class="loading loading-spinner {spinnerSizeClass} text-primary" aria-hidden="true"
+			></span>
+			<p class="text-sm text-base-content/70">Loading...</p>
+		</div>
+	{:else}
+		<!-- Icon -->
+		{#if icon}
+			<div class={iconContainerClasses} aria-hidden="true">
+				{@render icon()}
+			</div>
+		{:else}
+			<!-- Default empty state icon -->
+			<div class={iconContainerClasses} aria-hidden="true">
+				<svg
+					class={defaultIconClasses}
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="1.5"
+						d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+					></path>
+				</svg>
+			</div>
+		{/if}
+
+		<!-- Title -->
+		{#if title}
+			<h3 id={titleId} class={titleClasses}>
+				{title}
+			</h3>
+		{/if}
+
+		<!-- Description -->
+		{#if description}
+			<p id={descriptionId} class={descriptionClasses}>
+				{description}
+			</p>
+		{/if}
+
+		<!-- Custom content slot -->
+		{#if children}
+			<div class="mt-4">
+				{@render children()}
+			</div>
+		{/if}
+
+		<!-- Actions -->
+		{#if actions}
+			<div class={actionsClasses}>
+				{@render actions()}
+			</div>
+		{/if}
+	{/if}
+</div>


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements a fully functional EmptyState component for the hexaWebShare component library. The EmptyState component provides a consistent way to display empty states across the application with customizable styling and behavior.

**Key Features:**
- Svelte 5 implementation with runes ($props, $derived)
- TypeScript interfaces for type safety
- Multiple visual variants (primary, secondary, accent, neutral, info, success, warning, error)
- Three size presets (sm, md, lg)
- Loading and disabled states
- Bordered and filled style options
- Custom icon, content, and action slots
- Full accessibility support with ARIA attributes
- Comprehensive Storybook documentation

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

Using: `feat(EmptyState): add empty state component with DaisyUI styling`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: `<type>/<short-description>` (e.g., feat/add-empty-state-component)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted with Prettier
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran Storybook build successfully (pnpm build-storybook)
- [x] For UI changes, I added Storybook stories demonstrating all variants
- [x] I linked related issues using keywords like Closes #90 
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #90 