### PR TITLE
feat(core):  implement popover component

### DIFF
--- a/hexawebshare/src/components/core/overlay-navigation/Popover.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Popover.stories.svelte
@@ -1,0 +1,317 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Popover from './Popover.svelte';
+	import Button from '../buttons/Button.svelte';
+	import Paragraph from '../typography/Paragraph.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Overlay Navigation/Popover',
+		component: Popover,
+		tags: ['autodocs'],
+		argTypes: {
+			placement: {
+				control: { type: 'select' },
+				options: ['top', 'bottom', 'left', 'right'],
+				description: 'Popover placement relative to the trigger'
+			},
+			align: {
+				control: { type: 'select' },
+				options: ['start', 'center', 'end'],
+				description: 'Alignment of the popover content'
+			},
+			tone: {
+				control: { type: 'select' },
+				options: ['neutral', 'primary', 'secondary', 'accent', 'info', 'success', 'warning', 'error'],
+				description: 'Color tone for the popover content'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['sm', 'md', 'lg'],
+				description: 'Content size'
+			},
+			defaultOpen: {
+				control: 'boolean',
+				description: 'Initial open state for uncontrolled usage'
+			},
+			closeOnOutsideClick: {
+				control: 'boolean',
+				description: 'Close when clicking outside the popover'
+			},
+			closeOnEscape: {
+				control: 'boolean',
+				description: 'Close when pressing Escape'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Disable interactions'
+			},
+			contentClass: {
+				control: 'text',
+				description: 'Additional classes for the popover content'
+			},
+			triggerClass: {
+				control: 'text',
+				description: 'Additional classes for the trigger wrapper'
+			}
+		},
+		args: {
+			placement: 'bottom',
+			align: 'center',
+			tone: 'neutral',
+			size: 'md',
+			defaultOpen: false,
+			closeOnOutsideClick: true,
+			closeOnEscape: true,
+			disabled: false
+		}
+	});
+</script>
+
+<script lang="ts">
+	import Badge from '../media/Badge.svelte';
+
+	let controlledOpen = $state(false);
+</script>
+
+<Story name="Default">
+	<Popover>
+		{#snippet trigger()}
+			<Button label="Toggle popover" />
+		{/snippet}
+		{#snippet children()}
+			<div class="space-y-1">
+				<p class="font-semibold">Popover title</p>
+				<p class="text-sm text-base-content/80">Helpful supporting text for the trigger.</p>
+			</div>
+		{/snippet}
+	</Popover>
+</Story>
+
+<Story name="Top" args={{ placement: 'top' }}>
+	<Popover placement="top">
+		{#snippet trigger()}
+			<Button label="Top placement" />
+		{/snippet}
+		{#snippet children()}
+			<p class="text-sm">This popover appears above the trigger.</p>
+		{/snippet}
+	</Popover>
+</Story>
+
+<Story name="Left" args={{ placement: 'left', align: 'center' }}>
+	<div class="flex justify-center">
+		<Popover placement="left" align="center">
+			{#snippet trigger()}
+				<Button label="Left placement" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Content aligned to the left of the trigger.</p>
+			{/snippet}
+		</Popover>
+	</div>
+</Story>
+
+<Story name="Right" args={{ placement: 'right', align: 'center' }}>
+	<div class="flex justify-center">
+		<Popover placement="right" align="center">
+			{#snippet trigger()}
+				<Button label="Right placement" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Content aligned to the right of the trigger.</p>
+			{/snippet}
+		</Popover>
+	</div>
+</Story>
+
+<Story name="Alignment Start" args={{ align: 'start' }}>
+	<Popover align="start">
+		{#snippet trigger()}
+			<Button label="Aligned start" />
+		{/snippet}
+		{#snippet children()}
+			<div class="text-sm space-y-1">
+				<p class="font-semibold">Aligned start</p>
+				<p>Useful for left-anchored tooltips or menus.</p>
+			</div>
+		{/snippet}
+	</Popover>
+</Story>
+
+<Story name="Tones">
+	<div class="flex flex-wrap gap-4">
+		<Popover tone="primary">
+			{#snippet trigger()}
+				<Button label="Primary" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Primary tone with brand emphasis.</p>
+			{/snippet}
+		</Popover>
+		<Popover tone="info">
+			{#snippet trigger()}
+				<Button label="Info" variant="info" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Information tone for guidance.</p>
+			{/snippet}
+		</Popover>
+		<Popover tone="success">
+			{#snippet trigger()}
+				<Button label="Success" variant="success" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Success tone for confirmations.</p>
+			{/snippet}
+		</Popover>
+		<Popover tone="warning">
+			{#snippet trigger()}
+				<Button label="Warning" variant="warning" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Warning tone for cautions.</p>
+			{/snippet}
+		</Popover>
+		<Popover tone="error">
+			{#snippet trigger()}
+				<Button label="Error" variant="error" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Error tone for critical alerts.</p>
+			{/snippet}
+		</Popover>
+	</div>
+</Story>
+
+<Story name="Sizes">
+	<div class="flex flex-wrap gap-4">
+		<Popover size="sm">
+			{#snippet trigger()}
+				<Button label="Small" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Compact content for concise notes.</p>
+			{/snippet}
+		</Popover>
+		<Popover size="md">
+			{#snippet trigger()}
+				<Button label="Medium" />
+			{/snippet}
+			{#snippet children()}
+				<p class="text-sm">Default sizing for most use cases.</p>
+			{/snippet}
+		</Popover>
+		<Popover size="lg">
+			{#snippet trigger()}
+				<Button label="Large" />
+			{/snippet}
+			{#snippet children()}
+				<div class="space-y-1">
+					<p class="font-semibold">Large popover</p>
+					<Paragraph size="sm" variant="muted">
+						Great for richer explanations or short forms inside overlays.
+					</Paragraph>
+				</div>
+			{/snippet}
+		</Popover>
+	</div>
+</Story>
+
+<Story name="With Badges">
+	<Popover>
+		{#snippet trigger()}
+			<Button label="Popover with badge" />
+		{/snippet}
+		{#snippet children()}
+			<div class="flex items-center gap-2">
+				<p class="text-sm">Attach metadata inside popovers.</p>
+				<Badge label="New" variant="success" />
+			</div>
+		{/snippet}
+	</Popover>
+</Story>
+
+<Story name="Persistent" args={{ closeOnOutsideClick: false }}>
+	<Popover closeOnOutsideClick={false}>
+		{#snippet trigger()}
+			<Button label="Persistent popover" />
+		{/snippet}
+		{#snippet children()}
+			<p class="text-sm">Click outside will not dismiss this popover.</p>
+		{/snippet}
+	</Popover>
+</Story>
+
+<Story name="Disabled" args={{ disabled: true }}>
+	<Popover disabled={true}>
+		{#snippet trigger()}
+			<Button label="Disabled popover" disabled={true} />
+		{/snippet}
+		{#snippet children()}
+			<p class="text-sm">Interactions are disabled.</p>
+		{/snippet}
+	</Popover>
+</Story>
+
+<Story name="Controlled">
+	<div class="flex items-center gap-4">
+		<Button
+			label={controlledOpen ? 'Close popover' : 'Open popover'}
+			onclick={() => (controlledOpen = !controlledOpen)}
+		/>
+		<Popover
+			open={controlledOpen}
+			onOpenChange={(value) => (controlledOpen = value)}
+			closeOnOutsideClick={true}
+		>
+			{#snippet trigger()}
+				<Button label="Controlled trigger" variant="secondary" />
+			{/snippet}
+			{#snippet children()}
+				<div class="space-y-1">
+					<p class="font-semibold">Controlled popover</p>
+					<p class="text-sm text-base-content/80">State is managed externally.</p>
+				</div>
+			{/snippet}
+		</Popover>
+	</div>
+</Story>
+
+<Story
+	name="Playground"
+	args={{
+		placement: 'bottom',
+		align: 'center',
+		tone: 'neutral',
+		size: 'md',
+		defaultOpen: false
+	}}
+>
+	<Popover
+		placement="bottom"
+		align="center"
+		tone="neutral"
+		size="md"
+		defaultOpen={false}
+		closeOnOutsideClick={true}
+		closeOnEscape={true}
+	>
+		{#snippet trigger()}
+			<Button label="Interactive popover" />
+		{/snippet}
+		{#snippet children()}
+			<div class="space-y-1">
+				<p class="font-semibold">Playground</p>
+				<p class="text-sm text-base-content/80">
+					Use the controls to adjust placement, tone, and behavior.
+				</p>
+			</div>
+		{/snippet}
+	</Popover>
+</Story>
+

--- a/hexawebshare/src/components/core/overlay-navigation/Popover.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Popover.stories.svelte
@@ -26,7 +26,16 @@ SPDX-License-Identifier: MIT
 			},
 			tone: {
 				control: { type: 'select' },
-				options: ['neutral', 'primary', 'secondary', 'accent', 'info', 'success', 'warning', 'error'],
+				options: [
+					'neutral',
+					'primary',
+					'secondary',
+					'accent',
+					'info',
+					'success',
+					'warning',
+					'error'
+				],
 				description: 'Color tone for the popover content'
 			},
 			size: {
@@ -135,7 +144,7 @@ SPDX-License-Identifier: MIT
 			<Button label="Aligned start" />
 		{/snippet}
 		{#snippet children()}
-			<div class="text-sm space-y-1">
+			<div class="space-y-1 text-sm">
 				<p class="font-semibold">Aligned start</p>
 				<p>Useful for left-anchored tooltips or menus.</p>
 			</div>
@@ -314,4 +323,3 @@ SPDX-License-Identifier: MIT
 		{/snippet}
 	</Popover>
 </Story>
-

--- a/hexawebshare/src/components/core/overlay-navigation/Popover.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Popover.svelte
@@ -2,3 +2,327 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	type Placement = 'top' | 'bottom' | 'left' | 'right';
+	type Align = 'start' | 'center' | 'end';
+	type Tone =
+		| 'neutral'
+		| 'primary'
+		| 'secondary'
+		| 'accent'
+		| 'info'
+		| 'success'
+		| 'warning'
+		| 'error';
+	type Size = 'sm' | 'md' | 'lg';
+
+	interface Props {
+		trigger?: Snippet;
+		children?: Snippet;
+		open?: boolean;
+		defaultOpen?: boolean;
+		placement?: Placement;
+		align?: Align;
+		tone?: Tone;
+		size?: Size;
+		closeOnOutsideClick?: boolean;
+		closeOnEscape?: boolean;
+		disabled?: boolean;
+		ariaLabel?: string;
+		ariaDescribedBy?: string;
+		triggerAriaLabel?: string;
+		class?: string;
+		triggerClass?: string;
+		contentClass?: string;
+		onOpenChange?: (open: boolean) => void;
+	}
+
+	const {
+		trigger,
+		children,
+		open,
+		defaultOpen = false,
+		placement = 'bottom',
+		align = 'center',
+		tone = 'neutral',
+		size = 'md',
+		closeOnOutsideClick = true,
+		closeOnEscape = true,
+		disabled = false,
+		ariaLabel,
+		ariaDescribedBy,
+		triggerAriaLabel,
+		class: className = '',
+		triggerClass = '',
+		contentClass = '',
+		onOpenChange,
+		...props
+	}: Props = $props();
+
+	const isControlled = open !== undefined;
+
+	let internalOpen = $state(defaultOpen);
+	let popoverElement = $state<HTMLDivElement | null>(null);
+	let triggerElement = $state<HTMLElement | null>(null);
+	let contentElement = $state<HTMLDivElement | null>(null);
+
+	const contentId = `popover-${crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
+
+	let isOpen = $derived(open ?? internalOpen);
+
+	function setOpen(next: boolean) {
+		if (disabled) return;
+		if (!isControlled) {
+			internalOpen = next;
+		}
+		onOpenChange?.(next);
+	}
+
+	function toggleOpen() {
+		setOpen(!isOpen);
+	}
+
+	function handleTriggerClick() {
+		if (disabled) return;
+		toggleOpen();
+	}
+
+	function handleTriggerKeydown(event: KeyboardEvent) {
+		if (disabled) return;
+		if (event.key === ' ' || event.key === 'Enter') {
+			event.preventDefault();
+			toggleOpen();
+		}
+		if (event.key === 'Escape' && isOpen) {
+			event.stopPropagation();
+			setOpen(false);
+			triggerElement?.focus();
+		}
+	}
+
+	// Close when clicking outside the popover
+	$effect(() => {
+		if (!isOpen || !closeOnOutsideClick) return;
+
+		function handlePointerDown(event: PointerEvent) {
+			if (!popoverElement) return;
+			const target = event.target as Node;
+			if (!popoverElement.contains(target)) {
+				setOpen(false);
+			}
+		}
+
+		document.addEventListener('pointerdown', handlePointerDown);
+		return () => {
+			document.removeEventListener('pointerdown', handlePointerDown);
+		};
+	});
+
+	// Close with Escape key
+	$effect(() => {
+		if (!isOpen || !closeOnEscape) return;
+
+		function handleKeydown(event: KeyboardEvent) {
+			if (event.key === 'Escape') {
+				setOpen(false);
+				triggerElement?.focus();
+			}
+		}
+
+		document.addEventListener('keydown', handleKeydown);
+		return () => {
+			document.removeEventListener('keydown', handleKeydown);
+		};
+	});
+
+	// Focus first focusable element when the popover opens
+	$effect(() => {
+		if (isOpen && contentElement) {
+			const focusable = contentElement.querySelector<HTMLElement>(
+				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+			);
+			focusable?.focus();
+		}
+	});
+
+	// Calculate position for fixed positioning (prevents overflow issues)
+	let popoverStyle = $state<string>('');
+
+	// Update position when popover opens or placement changes
+	$effect(() => {
+		if (!isOpen || !triggerElement || !contentElement) {
+			popoverStyle = '';
+			return;
+		}
+
+		const updatePosition = () => {
+			if (!triggerElement || !contentElement) return;
+
+			const triggerRect = triggerElement.getBoundingClientRect();
+			const contentRect = contentElement.getBoundingClientRect();
+			const viewportWidth = window.innerWidth;
+			const viewportHeight = window.innerHeight;
+			const spacing = 8; // 8px spacing (mt-2 equivalent)
+
+			let top = 0;
+			let left = 0;
+
+			// Calculate position based on placement
+			if (placement === 'bottom') {
+				top = triggerRect.bottom + spacing;
+				if (align === 'start') {
+					left = triggerRect.left;
+				} else if (align === 'end') {
+					left = triggerRect.right - contentRect.width;
+				} else {
+					left = triggerRect.left + triggerRect.width / 2 - contentRect.width / 2;
+				}
+			} else if (placement === 'top') {
+				top = triggerRect.top - contentRect.height - spacing;
+				if (align === 'start') {
+					left = triggerRect.left;
+				} else if (align === 'end') {
+					left = triggerRect.right - contentRect.width;
+				} else {
+					left = triggerRect.left + triggerRect.width / 2 - contentRect.width / 2;
+				}
+			} else if (placement === 'right') {
+				left = triggerRect.right + spacing;
+				if (align === 'start') {
+					top = triggerRect.top;
+				} else if (align === 'end') {
+					top = triggerRect.bottom - contentRect.height;
+				} else {
+					top = triggerRect.top + triggerRect.height / 2 - contentRect.height / 2;
+				}
+			} else if (placement === 'left') {
+				left = triggerRect.left - contentRect.width - spacing;
+				if (align === 'start') {
+					top = triggerRect.top;
+				} else if (align === 'end') {
+					top = triggerRect.bottom - contentRect.height;
+				} else {
+					top = triggerRect.top + triggerRect.height / 2 - contentRect.height / 2;
+				}
+			}
+
+			// Keep popover within viewport bounds
+			if (left < 0) left = spacing;
+			if (left + contentRect.width > viewportWidth) {
+				left = viewportWidth - contentRect.width - spacing;
+			}
+			if (top < 0) top = spacing;
+			if (top + contentRect.height > viewportHeight) {
+				top = viewportHeight - contentRect.height - spacing;
+			}
+
+			popoverStyle = `position: fixed; top: ${top}px; left: ${left}px; z-index: 50;`;
+		};
+
+		// Use requestAnimationFrame to ensure element is rendered
+		requestAnimationFrame(() => {
+			updatePosition();
+		});
+
+		// Update on scroll/resize
+		window.addEventListener('scroll', updatePosition, true);
+		window.addEventListener('resize', updatePosition);
+
+		return () => {
+			window.removeEventListener('scroll', updatePosition, true);
+			window.removeEventListener('resize', updatePosition);
+		};
+	});
+
+	// Positioning classes for popover content (fallback for absolute positioning)
+	let contentPositionClasses = $derived.by(() => {
+		const base = ['z-50'];
+		return base.join(' ');
+	});
+
+	let popoverClasses = $derived(
+		['relative', 'inline-block', disabled && 'opacity-60 pointer-events-none', className]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	let triggerClasses = $derived(['w-fit', triggerClass].filter(Boolean).join(' '));
+
+	let contentClasses = $derived(
+		[
+			'border',
+			'border-base-300',
+			'bg-base-100',
+			'rounded-box',
+			'shadow-lg',
+			'p-4',
+			'max-w-full',
+			'text-base',
+			size === 'sm' && 'text-sm max-w-xs p-2',
+			size === 'md' && 'max-w-sm',
+			size === 'lg' && 'max-w-md p-6',
+			tone === 'primary' && 'bg-primary text-primary-content border-primary',
+			tone === 'secondary' && 'bg-secondary text-secondary-content border-secondary',
+			tone === 'accent' && 'bg-accent text-accent-content border-accent',
+			tone === 'info' && 'bg-info text-info-content border-info',
+			tone === 'success' && 'bg-success text-success-content border-success',
+			tone === 'warning' && 'bg-warning text-warning-content border-warning',
+			tone === 'error' && 'bg-error text-error-content border-error',
+			contentClass
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<div
+	bind:this={popoverElement}
+	class={popoverClasses}
+	data-state={isOpen ? 'open' : 'closed'}
+	{...props}
+>
+	<div
+		bind:this={triggerElement}
+		class={triggerClasses}
+		role="button"
+		tabindex={disabled ? -1 : 0}
+		aria-haspopup="dialog"
+		aria-expanded={isOpen}
+		aria-controls={contentId}
+		aria-label={triggerAriaLabel}
+		onclick={handleTriggerClick}
+		onkeydown={handleTriggerKeydown}
+	>
+		{#if trigger}
+			{@render trigger()}
+		{:else}
+			<button class="btn btn-primary" type="button">Toggle popover</button>
+		{/if}
+	</div>
+
+	{#if isOpen}
+		<div
+			id={contentId}
+			bind:this={contentElement}
+			class={contentPositionClasses + ' ' + contentClasses}
+			style={popoverStyle}
+			role="dialog"
+			aria-label={ariaLabel}
+			aria-describedby={ariaDescribedBy}
+			aria-hidden={false}
+			data-open={isOpen}
+		>
+			{#if children}
+				{@render children()}
+			{:else}
+				<div class="space-y-1">
+					<p class="font-semibold">Popover title</p>
+					<p class="text-sm text-base-content/80">Add your popover content here.</p>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements a fully functional Popover component for the hexaWebShare component library. The component was previously an empty skeleton file and now includes:

- Complete Svelte 5 implementation using runes ($props, $derived, $state)
- TypeScript interfaces for all props with proper type safety
- DaisyUI styling with static classes (no dynamic string interpolation)
- Fixed positioning to prevent container overflow issues
- Comprehensive accessibility features (ARIA labels, keyboard navigation, focus management)
- Controlled and uncontrolled state management
- Multiple placement options (top, bottom, left, right) with alignment support
- Various tone variants (neutral, primary, secondary, accent, info, success, warning, error)
- Size variants (sm, md, lg)
- Comprehensive Storybook stories demonstrating all variants and use cases

The component uses `fixed` positioning instead of `absolute` to prevent overflow issues when used inside containers with `overflow: hidden`. Position is calculated dynamically based on the trigger element's viewport position and automatically adjusts to stay within viewport bounds.

Closes #73

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

**PR Title:** `feat(core): implement Popover component with Storybook stories`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (feat/implement-popover-component)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (if applicable)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes
- [x] For UI changes, I added Storybook stories demonstrating all variants
- [x] I linked related issues using keywords like Closes #73
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #73

