### PR TITLE
fix(Accordion): fix multiple mode reactivity and Storybook controls

### DIFF
--- a/hexawebshare/src/components/core/overlay-navigation/Accordion.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Accordion.stories.svelte
@@ -1,0 +1,178 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Accordion from './Accordion.svelte';
+	import AccordionItem from './AccordionItem.svelte';
+	import AccordionWrapper from './AccordionWrapper.svelte';
+	import { fn } from 'storybook/test';
+
+	const { Story } = defineMeta({
+		title: 'Core/Overlay Navigation/Accordion',
+		component: AccordionWrapper,
+		tags: ['autodocs'],
+		argTypes: {
+			multiple: { control: 'boolean' },
+			variant: {
+				control: { type: 'select' },
+				options: ['default', 'bordered', 'ghost']
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['sm', 'md', 'lg']
+			},
+			disabled: { control: 'boolean' }
+		},
+		args: {
+			variant: 'default',
+			size: 'md',
+			multiple: false,
+			disabled: false
+		}
+	});
+</script>
+
+<!-- Default Story with Controls -->
+<Story
+	name="Default"
+	args={{
+		variant: 'default',
+		size: 'md',
+		multiple: false,
+		disabled: false
+	}}
+/>
+
+<!-- Basic Accordion -->
+<Story name="Basic">
+	<Accordion>
+		<AccordionItem title="Item 1" index={0}>
+			<p>This is the content for item 1. It can contain any HTML or components.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 2" index={1}>
+			<p>
+				This is the content for item 2. You can add multiple paragraphs, lists, or other components.
+			</p>
+		</AccordionItem>
+		<AccordionItem title="Item 3" index={2}>
+			<p>
+				This is the content for item 3. The accordion allows you to organize content in a
+				collapsible format.
+			</p>
+		</AccordionItem>
+	</Accordion>
+</Story>
+
+<!-- Multiple Open -->
+<Story
+	name="Multiple Open"
+	args={{
+		multiple: true,
+		variant: 'default',
+		size: 'md',
+		disabled: false
+	}}
+/>
+
+<!-- Default Open -->
+<Story name="Default Open">
+	<Accordion defaultOpen={0}>
+		<AccordionItem title="Item 1 (Open by default)" index={0}>
+			<p>This item is open by default. You can specify which items should be open initially.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 2" index={1}>
+			<p>This item is closed by default.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 3" index={2}>
+			<p>This item is also closed by default.</p>
+		</AccordionItem>
+	</Accordion>
+</Story>
+
+<!-- Multiple Default Open -->
+<Story
+	name="Multiple Default Open"
+	args={{
+		multiple: true,
+		defaultOpen: [0, 2],
+		variant: 'default',
+		size: 'md',
+		disabled: false
+	}}
+/>
+
+<!-- Variants -->
+<Story name="Bordered Variant">
+	<Accordion variant="bordered">
+		<AccordionItem title="Item 1" index={0}>
+			<p>The bordered variant adds a border around the accordion.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 2" index={1}>
+			<p>Each item is separated by a divider.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 3" index={2}>
+			<p>This creates a more structured appearance.</p>
+		</AccordionItem>
+	</Accordion>
+</Story>
+
+<Story name="Ghost Variant">
+	<Accordion variant="ghost">
+		<AccordionItem title="Item 1" index={0}>
+			<p>The ghost variant has a lighter background color.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 2" index={1}>
+			<p>It's useful for minimal designs.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 3" index={2}>
+			<p>Perfect for clean, modern interfaces.</p>
+		</AccordionItem>
+	</Accordion>
+</Story>
+
+<!-- Sizes -->
+<Story name="Small Size">
+	<Accordion size="sm">
+		<AccordionItem title="Small Item 1" index={0}>
+			<p>This accordion uses the small size variant.</p>
+		</AccordionItem>
+		<AccordionItem title="Small Item 2" index={1}>
+			<p>Text and spacing are reduced for compact layouts.</p>
+		</AccordionItem>
+	</Accordion>
+</Story>
+
+<Story name="Large Size">
+	<Accordion size="lg">
+		<AccordionItem title="Large Item 1" index={0}>
+			<p>This accordion uses the large size variant.</p>
+		</AccordionItem>
+		<AccordionItem title="Large Item 2" index={1}>
+			<p>Text and spacing are increased for better readability.</p>
+		</AccordionItem>
+	</Accordion>
+</Story>
+
+<!-- Disabled -->
+<Story name="Disabled">
+	<Accordion disabled={true}>
+		<AccordionItem title="Item 1" index={0}>
+			<p>This accordion is disabled and cannot be interacted with.</p>
+		</AccordionItem>
+		<AccordionItem title="Item 2" index={1}>
+			<p>All items are disabled when the accordion is disabled.</p>
+		</AccordionItem>
+	</Accordion>
+</Story>
+
+<!-- Standalone Item -->
+<Story name="Standalone Item">
+	<AccordionItem title="Standalone Accordion Item">
+		<p>
+			AccordionItem can be used standalone without the Accordion wrapper. It manages its own state.
+		</p>
+	</AccordionItem>
+</Story>

--- a/hexawebshare/src/components/core/overlay-navigation/Accordion.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Accordion.svelte
@@ -2,3 +2,143 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import { setContext } from 'svelte';
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Props interface for the Accordion component
+	 */
+	interface Props {
+		/**
+		 * Whether multiple items can be open at the same time
+		 * @default false
+		 */
+		multiple?: boolean;
+		/**
+		 * Index or array of indices of initially open items
+		 * @default []
+		 */
+		defaultOpen?: number | number[];
+		/**
+		 * Visual variant of the accordion
+		 * @default 'default'
+		 */
+		variant?: 'default' | 'bordered' | 'ghost';
+		/**
+		 * Size of the accordion items
+		 * @default 'md'
+		 */
+		size?: 'sm' | 'md' | 'lg';
+		/**
+		 * Whether the accordion is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Accordion items content (using Svelte 5 snippets)
+		 */
+		children?: Snippet;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+		/**
+		 * Accessible label for the accordion
+		 */
+		ariaLabel?: string;
+		/**
+		 * Callback when an item is opened
+		 */
+		onItemOpen?: (index: number) => void;
+		/**
+		 * Callback when an item is closed
+		 */
+		onItemClose?: (index: number) => void;
+	}
+
+	const {
+		multiple = false,
+		defaultOpen = [],
+		variant = 'default',
+		size = 'md',
+		disabled = false,
+		children,
+		class: className = '',
+		ariaLabel,
+		onItemOpen,
+		onItemClose,
+		...props
+	}: Props = $props();
+
+	// Track open items
+	let openItems = $state<Set<number>>(
+		new Set(
+			Array.isArray(defaultOpen) ? defaultOpen : defaultOpen !== undefined ? [defaultOpen] : []
+		)
+	);
+
+	// Create reactive context object first
+	const accordionContext = $state({
+		toggleItem: (index: number) => {
+			if (accordionContext.disabled) return;
+
+			if (openItems.has(index)) {
+				openItems.delete(index);
+				if (onItemClose) onItemClose(index);
+			} else {
+				// Use current multiple value from context (reactive)
+				if (!accordionContext.multiple) {
+					openItems.clear();
+				}
+				openItems.add(index);
+				if (onItemOpen) onItemOpen(index);
+			}
+			// Trigger reactivity
+			openItems = new Set(openItems);
+		},
+		isItemOpen: (index: number): boolean => {
+			return openItems.has(index);
+		},
+		multiple,
+		disabled,
+		size
+	});
+
+	// Update context when props change - this ensures toggleItem uses latest multiple value
+	$effect(() => {
+		accordionContext.multiple = multiple;
+		accordionContext.disabled = disabled;
+		accordionContext.size = size;
+
+		// If multiple changes from true to false, close all but the first open item
+		if (!multiple && openItems.size > 1) {
+			const firstOpen = Array.from(openItems)[0];
+			openItems = new Set([firstOpen]);
+		}
+	});
+
+	// Share accordion state with child components via context
+	setContext('accordion', accordionContext);
+
+	// Accordion container classes
+	let accordionClasses = $derived(
+		[
+			'accordion',
+			variant === 'bordered' && 'border border-base-300 rounded-lg divide-y divide-base-300',
+			variant === 'ghost' && 'bg-base-100',
+			variant === 'default' && 'bg-base-200',
+			disabled && 'opacity-50 pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<div class={accordionClasses} role="region" aria-label={ariaLabel || 'Accordion'} {...props}>
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/hexawebshare/src/components/core/overlay-navigation/AccordionItem.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/AccordionItem.svelte
@@ -1,0 +1,197 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Props interface for the AccordionItem component
+	 */
+	interface Props {
+		/**
+		 * Title text for the accordion item
+		 */
+		title: string;
+		/**
+		 * Content to display when the item is expanded
+		 */
+		children?: Snippet;
+		/**
+		 * Optional icon snippet to display before the title
+		 */
+		icon?: Snippet;
+		/**
+		 * Whether this item is initially open
+		 * @default false
+		 */
+		defaultOpen?: boolean;
+		/**
+		 * Unique index for this item (auto-generated if not provided)
+		 */
+		index?: number;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+		/**
+		 * Accessible label for this item
+		 */
+		ariaLabel?: string;
+	}
+
+	const {
+		title,
+		children,
+		icon,
+		defaultOpen = false,
+		index,
+		class: className = '',
+		ariaLabel,
+		...props
+	}: Props = $props();
+
+	// Get accordion context
+	const accordionContext = getContext<{
+		toggleItem: (index: number) => void;
+		isItemOpen: (index: number) => boolean;
+		multiple: boolean;
+		disabled: boolean;
+		size: 'sm' | 'md' | 'lg';
+	}>('accordion');
+
+	// Generate unique index if not provided (using crypto or fallback)
+	// Use a counter for sequential indices when in Accordion context
+	let itemIndex = $state(
+		index ??
+			(typeof crypto !== 'undefined' && crypto.randomUUID
+				? parseInt(crypto.randomUUID().replace(/-/g, ''), 16) % 1000000
+				: Math.floor(Math.random() * 1000000))
+	);
+
+	// Local state for standalone usage (when not in Accordion context)
+	let localOpen = $state(defaultOpen);
+
+	// Get open state from context or use local state - make it reactive
+	let isOpen = $derived.by(() => {
+		if (accordionContext) {
+			return accordionContext.isItemOpen(itemIndex);
+		}
+		return localOpen;
+	});
+
+	// Toggle this item
+	function toggle() {
+		if (accordionContext) {
+			accordionContext.toggleItem(itemIndex);
+		} else {
+			localOpen = !localOpen;
+		}
+	}
+
+	// Handle checkbox change - DaisyUI automatically handles collapse-open class based on checked state
+	function handleChange(event: Event) {
+		toggle();
+	}
+
+	// Handle keyboard events for title
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			toggle();
+		}
+	}
+
+	// Get size from context or default to 'md' - make it reactive
+	const size = $derived.by(() => accordionContext?.size ?? 'md');
+
+	// Collapse classes using DaisyUI
+	// Note: DaisyUI automatically adds 'collapse-open' class when checkbox is checked
+	let collapseClasses = $derived(
+		[
+			'collapse',
+			'collapse-arrow',
+			size === 'sm' && 'text-sm',
+			size === 'md' && 'text-base',
+			size === 'lg' && 'text-lg',
+			accordionContext?.disabled && 'opacity-50 pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Title classes with size-based padding
+	let titleClasses = $derived(
+		[
+			'collapse-title',
+			'font-medium',
+			'flex items-center gap-2',
+			size === 'sm' && 'text-sm py-2 px-3 min-h-[2.5rem]',
+			size === 'md' && 'text-base py-3 px-4 min-h-[3rem]',
+			size === 'lg' && 'text-lg py-4 px-5 min-h-[3.5rem]'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Content classes with size-based padding
+	let contentClasses = $derived(
+		[
+			'collapse-content',
+			size === 'sm' && 'text-sm py-2 px-3',
+			size === 'md' && 'text-base py-3 px-4',
+			size === 'lg' && 'text-lg py-4 px-5'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Unique ID for accessibility
+	const itemId = `accordion-item-${itemIndex}`;
+	const contentId = `accordion-content-${itemIndex}`;
+
+	// Checkbox element reference for state synchronization
+	let checkboxElement = $state<HTMLInputElement | null>(null);
+
+	// Sync checkbox checked state with isOpen
+	$effect(() => {
+		if (checkboxElement) {
+			checkboxElement.checked = isOpen;
+		}
+	});
+</script>
+
+<div class={collapseClasses} {...props}>
+	<input
+		bind:this={checkboxElement}
+		type="checkbox"
+		onchange={handleChange}
+		aria-expanded={isOpen}
+		aria-controls={contentId}
+		aria-label={ariaLabel || title}
+		disabled={accordionContext?.disabled}
+	/>
+	<div
+		class={titleClasses}
+		id={itemId}
+		role="button"
+		tabindex="0"
+		onclick={toggle}
+		onkeydown={handleKeyDown}
+	>
+		{#if icon}
+			<span class="accordion-item-icon" aria-hidden="true">
+				{@render icon()}
+			</span>
+		{/if}
+		<span>{title}</span>
+	</div>
+	<div class={contentClasses} id={contentId} role="region" aria-labelledby={itemId}>
+		{#if children}
+			{@render children()}
+		{/if}
+	</div>
+</div>

--- a/hexawebshare/src/components/core/overlay-navigation/AccordionWrapper.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/AccordionWrapper.svelte
@@ -1,0 +1,55 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script lang="ts">
+	import Accordion from './Accordion.svelte';
+	import AccordionItem from './AccordionItem.svelte';
+
+	interface Props {
+		variant?: 'default' | 'bordered' | 'ghost';
+		size?: 'sm' | 'md' | 'lg';
+		multiple?: boolean;
+		disabled?: boolean;
+		defaultOpen?: number | number[];
+	}
+
+	const {
+		variant = 'default',
+		size = 'md',
+		multiple = false,
+		disabled = false,
+		defaultOpen
+	}: Props = $props();
+</script>
+
+<Accordion {variant} {size} {multiple} {disabled} {defaultOpen}>
+	<AccordionItem title="Frequently Asked Questions" index={0}>
+		<div class="space-y-4">
+			<h4 class="font-semibold">Question 1</h4>
+			<p>
+				This is a detailed answer that can span multiple paragraphs and include various content
+				types.
+			</p>
+			<ul class="list-inside list-disc space-y-2">
+				<li>Feature 1</li>
+				<li>Feature 2</li>
+				<li>Feature 3</li>
+			</ul>
+		</div>
+	</AccordionItem>
+	<AccordionItem title="Product Information" index={1}>
+		<div class="space-y-4">
+			<p>Product details and specifications can be organized in accordion items.</p>
+			<div class="rounded bg-base-200 p-4">
+				<p class="text-sm">Additional information can be displayed in styled containers.</p>
+			</div>
+		</div>
+	</AccordionItem>
+	<AccordionItem title="Additional Details" index={2}>
+		<div class="space-y-4">
+			<p>This is the third item. It can be used to demonstrate multiple open functionality.</p>
+		</div>
+	</AccordionItem>
+</Accordion>


### PR DESCRIPTION
# Pull Request

## 📄 Summary

> This PR fixes the issue where the `multiple` control was not working correctly in Accordion Storybook stories. The `toggleItem` function was using a closure that captured the initial `multiple` prop value, preventing it from reacting to changes. Additionally, "Multiple Open" and "Multiple Default Open" stories were not using `AccordionWrapper`, which meant controls were not properly displayed or functional.

**Changes:**
- Refactored `toggleItem` function to use reactive `accordionContext.multiple` value instead of closure
- Updated "Multiple Open" and "Multiple Default Open" stories to use `AccordionWrapper` with proper `args`
- Added `defaultOpen` prop to `AccordionWrapper` for better Storybook integration
- Added third item to `AccordionWrapper` to support multiple default open scenarios

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---


## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., fix/accordion-multiple-control)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (if applicable)
- [x] I updated / checked package.json for dependency changes
- [x] For UI changes, I tested in Storybook and verified controls work correctly
- [ ] I linked related issues using keywords like Closes #42
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues


Closes #81 

## 💬 Additional Notes (Optional)

### Testing Instructions

1. Open Storybook and navigate to **Core > Overlay Navigation > Accordion**
2. Select the **"Multiple Open"** story
3. Verify that the `multiple` control in the controls panel shows `true`
4. Click on multiple accordion items - they should all stay open simultaneously
5. Select the **"Multiple Default Open"** story
6. Verify that the `multiple` control shows `true` and `defaultOpen` shows `[0, 2]`
7. Verify that items 1 and 3 are open by default
8. Test changing the `multiple` control from `true` to `false` - only one item should remain open
9. Test changing the `multiple` control from `false` to `true` - multiple items should be able to open

### Technical Details

- The fix involved moving `toggleItem` and `isItemOpen` functions inside the `accordionContext` object definition to ensure they always use the reactive `accordionContext.multiple` value
- Story stories were updated to use `AccordionWrapper` with `args` to ensure Storybook controls work correctly
- `AccordionWrapper` was extended to support `defaultOpen` prop for better Storybook integration