### PR TITLE
feat(core): implement menu component

### DIFF
--- a/hexawebshare/src/components/core/overlay-navigation/Menu.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Menu.stories.svelte
@@ -45,10 +45,10 @@ SPDX-License-Identifier: MIT
 	];
 
 	const itemsWithLinks = [
-		{ id: '1', label: 'Home', href: '#' },
-		{ id: '2', label: 'About', href: '#' },
-		{ id: '3', label: 'Services', href: '#' },
-		{ id: '4', label: 'Contact', href: '#' }
+		{ id: '1', label: 'Home', href: '/' },
+		{ id: '2', label: 'About', href: '/' },
+		{ id: '3', label: 'Services', href: '/' },
+		{ id: '4', label: 'Contact', href: '/' }
 	];
 
 	const complexItems = [
@@ -99,6 +99,26 @@ SPDX-License-Identifier: MIT
 	});
 </script>
 
+<script lang="ts">
+	import type { MenuItem } from './Menu.svelte';
+
+	let selectedItem = $state<string | number>('1');
+
+	const interactiveItems: MenuItem[] = [
+		{ id: '1', label: 'Option 1', onClick: () => (selectedItem = '1') },
+		{ id: '2', label: 'Option 2', onClick: () => (selectedItem = '2') },
+		{ id: '3', label: 'Option 3', onClick: () => (selectedItem = '3') }
+	];
+
+	// Update active state based on selection
+	let itemsWithActive = $derived(
+		interactiveItems.map((item) => ({
+			...item,
+			active: item.id === selectedItem
+		}))
+	);
+</script>
+
 <!-- Default Stories -->
 <Story name="Default" args={{ items: basicItems }} />
 
@@ -140,36 +160,15 @@ SPDX-License-Identifier: MIT
 <Story name="Slot Content">
 	<Menu ariaLabel="Custom menu with slot content">
 		{#snippet children()}
-			<li><a href="#">Custom Item 1</a></li>
-			<li><a href="#">Custom Item 2</a></li>
-			<li><a href="#">Custom Item 3</a></li>
+			<li><a href="/">Custom Item 1</a></li>
+			<li><a href="/">Custom Item 2</a></li>
+			<li><a href="/">Custom Item 3</a></li>
 		{/snippet}
 	</Menu>
 </Story>
 
 <!-- Interactive Example -->
 <Story name="Interactive">
-	<script lang="ts">
-		import Menu from './Menu.svelte';
-		import type { MenuItem } from './Menu.svelte';
-
-		let selectedItem = $state<string | number>('1');
-
-		const interactiveItems: MenuItem[] = [
-			{ id: '1', label: 'Option 1', onClick: () => (selectedItem = '1') },
-			{ id: '2', label: 'Option 2', onClick: () => (selectedItem = '2') },
-			{ id: '3', label: 'Option 3', onClick: () => (selectedItem = '3') }
-		];
-
-		// Update active state based on selection
-		let itemsWithActive = $derived(
-			interactiveItems.map((item) => ({
-				...item,
-				active: item.id === selectedItem
-			}))
-		);
-	</script>
-
 	<div class="space-y-4">
 		<Menu items={itemsWithActive} ariaLabel="Interactive menu" />
 		<p class="text-base-content/70 text-sm">

--- a/hexawebshare/src/components/core/overlay-navigation/Menu.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Menu.stories.svelte
@@ -178,14 +178,25 @@ SPDX-License-Identifier: MIT
 </Story>
 
 <!-- Horizontal Bordered -->
-<Story name="Horizontal Bordered" args={{ items: basicItems, orientation: 'horizontal', variant: 'bordered' }} />
+<Story
+	name="Horizontal Bordered"
+	args={{ items: basicItems, orientation: 'horizontal', variant: 'bordered' }}
+/>
 
 <!-- Compact Horizontal -->
-<Story name="Compact Horizontal" args={{ items: basicItems, orientation: 'horizontal', variant: 'compact' }} />
+<Story
+	name="Compact Horizontal"
+	args={{ items: basicItems, orientation: 'horizontal', variant: 'compact' }}
+/>
 
 <!-- Large Vertical -->
-<Story name="Large Vertical" args={{ items: itemsWithIcons, size: 'lg', orientation: 'vertical' }} />
+<Story
+	name="Large Vertical"
+	args={{ items: itemsWithIcons, size: 'lg', orientation: 'vertical' }}
+/>
 
 <!-- Small Horizontal -->
-<Story name="Small Horizontal" args={{ items: basicItems, size: 'sm', orientation: 'horizontal' }} />
-
+<Story
+	name="Small Horizontal"
+	args={{ items: basicItems, size: 'sm', orientation: 'horizontal' }}
+/>

--- a/hexawebshare/src/components/core/overlay-navigation/Menu.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Menu.stories.svelte
@@ -1,0 +1,192 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Menu from './Menu.svelte';
+	import { fn } from 'storybook/test';
+
+	// Sample menu items
+	const basicItems = [
+		{ id: '1', label: 'Home' },
+		{ id: '2', label: 'About' },
+		{ id: '3', label: 'Services' },
+		{ id: '4', label: 'Contact' }
+	];
+
+	const itemsWithIcons = [
+		{ id: '1', label: 'Dashboard', icon: '📊' },
+		{ id: '2', label: 'Settings', icon: '⚙️' },
+		{ id: '3', label: 'Profile', icon: '👤' },
+		{ id: '4', label: 'Logout', icon: '🚪' }
+	];
+
+	const itemsWithDescriptions = [
+		{ id: '1', label: 'Overview', description: 'View your dashboard' },
+		{ id: '2', label: 'Analytics', description: 'Track your metrics' },
+		{ id: '3', label: 'Reports', description: 'Generate reports' }
+	];
+
+	const itemsWithStates = [
+		{ id: '1', label: 'Active Item', active: true },
+		{ id: '2', label: 'Normal Item' },
+		{ id: '3', label: 'Disabled Item', disabled: true },
+		{ id: '4', label: 'Another Item' }
+	];
+
+	const itemsWithDividers = [
+		{ id: '1', label: 'File', divider: true },
+		{ id: '2', label: 'Edit', divider: true },
+		{ id: '3', label: 'View' },
+		{ id: '4', label: 'Help', divider: true },
+		{ id: '5', label: 'About' }
+	];
+
+	const itemsWithLinks = [
+		{ id: '1', label: 'Home', href: '#' },
+		{ id: '2', label: 'About', href: '#' },
+		{ id: '3', label: 'Services', href: '#' },
+		{ id: '4', label: 'Contact', href: '#' }
+	];
+
+	const complexItems = [
+		{ id: '1', label: 'Dashboard', icon: '📊', description: 'Main dashboard', active: true },
+		{ id: '2', label: 'Projects', icon: '📁', description: 'Manage projects' },
+		{ id: '3', label: 'Team', icon: '👥', description: 'Team members', divider: true },
+		{ id: '4', label: 'Settings', icon: '⚙️', description: 'Application settings' },
+		{ id: '5', label: 'Help', icon: '❓', description: 'Get help', disabled: true }
+	];
+
+	const { Story } = defineMeta({
+		title: 'Core/Overlay Navigation/Menu',
+		component: Menu,
+		tags: ['autodocs'],
+		argTypes: {
+			variant: {
+				control: { type: 'select' },
+				options: ['default', 'bordered', 'compact'],
+				description: 'Visual variant of the menu'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['sm', 'md', 'lg'],
+				description: 'Size preset for menu items'
+			},
+			orientation: {
+				control: { type: 'select' },
+				options: ['horizontal', 'vertical'],
+				description: 'Menu orientation'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Disable all menu items'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for the menu'
+			}
+		},
+		args: {
+			items: basicItems,
+			variant: 'default',
+			size: 'md',
+			orientation: 'vertical',
+			disabled: false,
+			onItemClick: fn()
+		}
+	});
+</script>
+
+<!-- Default Stories -->
+<Story name="Default" args={{ items: basicItems }} />
+
+<Story name="With Icons" args={{ items: itemsWithIcons }} />
+
+<Story name="With Descriptions" args={{ items: itemsWithDescriptions }} />
+
+<Story name="With Active State" args={{ items: itemsWithStates }} />
+
+<Story name="With Dividers" args={{ items: itemsWithDividers }} />
+
+<Story name="With Links" args={{ items: itemsWithLinks }} />
+
+<Story name="Complex Example" args={{ items: complexItems }} />
+
+<!-- Variant Stories -->
+<Story name="Bordered" args={{ items: basicItems, variant: 'bordered' }} />
+
+<Story name="Compact" args={{ items: basicItems, variant: 'compact' }} />
+
+<!-- Size Stories -->
+<Story name="Small" args={{ items: basicItems, size: 'sm' }} />
+
+<Story name="Medium" args={{ items: basicItems, size: 'md' }} />
+
+<Story name="Large" args={{ items: basicItems, size: 'lg' }} />
+
+<!-- Orientation Stories -->
+<Story name="Horizontal" args={{ items: basicItems, orientation: 'horizontal' }} />
+
+<Story name="Vertical" args={{ items: basicItems, orientation: 'vertical' }} />
+
+<!-- State Stories -->
+<Story name="Disabled" args={{ items: basicItems, disabled: true }} />
+
+<Story name="Disabled Items" args={{ items: itemsWithStates }} />
+
+<!-- Slot-based Content -->
+<Story name="Slot Content">
+	<Menu ariaLabel="Custom menu with slot content">
+		{#snippet children()}
+			<li><a href="#">Custom Item 1</a></li>
+			<li><a href="#">Custom Item 2</a></li>
+			<li><a href="#">Custom Item 3</a></li>
+		{/snippet}
+	</Menu>
+</Story>
+
+<!-- Interactive Example -->
+<Story name="Interactive">
+	<script lang="ts">
+		import Menu from './Menu.svelte';
+		import type { MenuItem } from './Menu.svelte';
+
+		let selectedItem = $state<string | number>('1');
+
+		const interactiveItems: MenuItem[] = [
+			{ id: '1', label: 'Option 1', onClick: () => (selectedItem = '1') },
+			{ id: '2', label: 'Option 2', onClick: () => (selectedItem = '2') },
+			{ id: '3', label: 'Option 3', onClick: () => (selectedItem = '3') }
+		];
+
+		// Update active state based on selection
+		let itemsWithActive = $derived(
+			interactiveItems.map((item) => ({
+				...item,
+				active: item.id === selectedItem
+			}))
+		);
+	</script>
+
+	<div class="space-y-4">
+		<Menu items={itemsWithActive} ariaLabel="Interactive menu" />
+		<p class="text-base-content/70 text-sm">
+			Selected: <strong>{selectedItem}</strong>
+		</p>
+	</div>
+</Story>
+
+<!-- Horizontal Bordered -->
+<Story name="Horizontal Bordered" args={{ items: basicItems, orientation: 'horizontal', variant: 'bordered' }} />
+
+<!-- Compact Horizontal -->
+<Story name="Compact Horizontal" args={{ items: basicItems, orientation: 'horizontal', variant: 'compact' }} />
+
+<!-- Large Vertical -->
+<Story name="Large Vertical" args={{ items: itemsWithIcons, size: 'lg', orientation: 'vertical' }} />
+
+<!-- Small Horizontal -->
+<Story name="Small Horizontal" args={{ items: basicItems, size: 'sm', orientation: 'horizontal' }} />
+

--- a/hexawebshare/src/components/core/overlay-navigation/Menu.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Menu.svelte
@@ -2,3 +2,326 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Menu item interface for programmatic rendering
+	 */
+	export interface MenuItem {
+		/**
+		 * Unique identifier for the menu item
+		 */
+		id: string | number;
+		/**
+		 * Label text displayed in the menu item
+		 */
+		label: string;
+		/**
+		 * Optional description or subtitle
+		 */
+		description?: string;
+		/**
+		 * Optional icon identifier (emoji or icon class)
+		 */
+		icon?: string;
+		/**
+		 * Whether the item is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Whether the item is active/selected
+		 * @default false
+		 */
+		active?: boolean;
+		/**
+		 * Whether to show a divider after this item
+		 * @default false
+		 */
+		divider?: boolean;
+		/**
+		 * Optional href for link items
+		 */
+		href?: string;
+		/**
+		 * Click handler function
+		 */
+		onClick?: () => void;
+	}
+
+	/**
+	 * Props interface for Menu component
+	 */
+	interface Props {
+		/**
+		 * Array of menu items to render programmatically
+		 */
+		items?: MenuItem[];
+		/**
+		 * Visual variant of the menu
+		 * @default 'default'
+		 */
+		variant?: 'default' | 'bordered' | 'compact';
+		/**
+		 * Size preset for the menu items
+		 * @default 'md'
+		 */
+		size?: 'sm' | 'md' | 'lg';
+		/**
+		 * Menu orientation
+		 * @default 'vertical'
+		 */
+		orientation?: 'horizontal' | 'vertical';
+		/**
+		 * Disable all menu items
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Accessible label for the menu
+		 */
+		ariaLabel?: string;
+		/**
+		 * ID of the element that labels this menu
+		 */
+		ariaLabelledby?: string;
+		/**
+		 * Custom slot content for rendering items manually
+		 */
+		children?: Snippet;
+		/**
+		 * Callback when an item is clicked
+		 */
+		onItemClick?: (item: MenuItem, index: number) => void;
+		/**
+		 * Additional CSS classes
+		 * @default ''
+		 */
+		class?: string;
+	}
+
+	const {
+		items = [],
+		variant = 'default',
+		size = 'md',
+		orientation = 'vertical',
+		disabled = false,
+		ariaLabel,
+		ariaLabelledby,
+		children,
+		onItemClick,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Generate unique ID for accessibility
+	const menuId = crypto.randomUUID?.() ?? `menu-${Math.random().toString(36).slice(2, 9)}`;
+
+	// Track focused item index for keyboard navigation
+	let focusedIndex = $state(-1);
+
+	// Computed menu classes
+	let menuClasses = $derived(
+		[
+			'menu',
+			orientation === 'horizontal' ? 'menu-horizontal' : 'menu-vertical',
+			variant === 'compact' && 'menu-compact',
+			size === 'sm' && 'menu-sm',
+			size === 'md' && 'menu-md',
+			size === 'lg' && 'menu-lg',
+			variant === 'bordered' && 'rounded-box border border-base-300 bg-base-100 p-2',
+			disabled && 'pointer-events-none opacity-60',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Compute item classes based on state
+	const getItemClasses = (item: MenuItem, index: number) =>
+		[
+			item.active && 'active',
+			item.disabled && 'disabled',
+			focusedIndex === index && 'focus'
+		]
+			.filter(Boolean)
+			.join(' ');
+
+	// Handle item click
+	const handleItemClick = (item: MenuItem, index: number) => {
+		if (item.disabled || disabled) return;
+		onItemClick?.(item, index);
+		if (item.onClick) {
+			item.onClick();
+		}
+	};
+
+	// Handle keyboard navigation
+	const handleKeyDown = (event: KeyboardEvent, item: MenuItem, index: number) => {
+		if (disabled || item.disabled) return;
+
+		const enabledItems = items.filter((i) => !i.disabled);
+		const currentEnabledIndex = enabledItems.findIndex((i) => i.id === item.id);
+
+		switch (event.key) {
+			case 'ArrowDown': {
+				if (orientation === 'vertical') {
+					event.preventDefault();
+					const nextIndex = (currentEnabledIndex + 1) % enabledItems.length;
+					const nextItem = enabledItems[nextIndex];
+					const nextRealIndex = items.findIndex((i) => i.id === nextItem.id);
+					focusedIndex = nextRealIndex;
+					focusItem(nextRealIndex);
+				}
+				break;
+			}
+			case 'ArrowUp': {
+				if (orientation === 'vertical') {
+					event.preventDefault();
+					const prevIndex = (currentEnabledIndex - 1 + enabledItems.length) % enabledItems.length;
+					const prevItem = enabledItems[prevIndex];
+					const prevRealIndex = items.findIndex((i) => i.id === prevItem.id);
+					focusedIndex = prevRealIndex;
+					focusItem(prevRealIndex);
+				}
+				break;
+			}
+			case 'ArrowRight': {
+				if (orientation === 'horizontal') {
+					event.preventDefault();
+					const nextIndex = (currentEnabledIndex + 1) % enabledItems.length;
+					const nextItem = enabledItems[nextIndex];
+					const nextRealIndex = items.findIndex((i) => i.id === nextItem.id);
+					focusedIndex = nextRealIndex;
+					focusItem(nextRealIndex);
+				}
+				break;
+			}
+			case 'ArrowLeft': {
+				if (orientation === 'horizontal') {
+					event.preventDefault();
+					const prevIndex = (currentEnabledIndex - 1 + enabledItems.length) % enabledItems.length;
+					const prevItem = enabledItems[prevIndex];
+					const prevRealIndex = items.findIndex((i) => i.id === prevItem.id);
+					focusedIndex = prevRealIndex;
+					focusItem(prevRealIndex);
+				}
+				break;
+			}
+			case 'Home': {
+				event.preventDefault();
+				const firstItem = enabledItems[0];
+				if (firstItem) {
+					const firstRealIndex = items.findIndex((i) => i.id === firstItem.id);
+					focusedIndex = firstRealIndex;
+					focusItem(firstRealIndex);
+				}
+				break;
+			}
+			case 'End': {
+				event.preventDefault();
+				const lastItem = enabledItems[enabledItems.length - 1];
+				if (lastItem) {
+					const lastRealIndex = items.findIndex((i) => i.id === lastItem.id);
+					focusedIndex = lastRealIndex;
+					focusItem(lastRealIndex);
+				}
+				break;
+			}
+			case 'Enter':
+			case ' ': {
+				event.preventDefault();
+				handleItemClick(item, index);
+				break;
+			}
+		}
+	};
+
+	// Focus a specific item by index
+	const focusItem = (index: number) => {
+		const element = document.getElementById(`${menuId}-item-${index}`);
+		if (element) {
+			element.focus();
+		}
+	};
+
+	// Handle focus events
+	const handleFocus = (index: number) => {
+		focusedIndex = index;
+	};
+
+	const handleBlur = () => {
+		focusedIndex = -1;
+	};
+</script>
+
+<ul
+	id={menuId}
+	class={menuClasses}
+	role="menu"
+	aria-label={ariaLabel}
+	aria-labelledby={ariaLabelledby}
+	aria-orientation={orientation}
+	aria-disabled={disabled}
+	{...props}
+>
+	{#if children}
+		{@render children()}
+	{:else}
+		{#each items as item, index (item.id)}
+			<li class={getItemClasses(item, index)}>
+				{#if item.href && !item.disabled}
+					<a
+						id="{menuId}-item-{index}"
+						href={item.href}
+						class="flex items-center gap-2"
+						tabindex={item.disabled ? -1 : 0}
+						aria-disabled={item.disabled}
+						onclick={() => handleItemClick(item, index)}
+						onkeydown={(e) => handleKeyDown(e, item, index)}
+						onfocus={() => handleFocus(index)}
+						onblur={handleBlur}
+					>
+						{#if item.icon}
+							<span class="text-lg" aria-hidden="true">{item.icon}</span>
+						{/if}
+						<span class="flex flex-col">
+							<span>{item.label}</span>
+							{#if item.description}
+								<span class="text-xs opacity-60">{item.description}</span>
+							{/if}
+						</span>
+					</a>
+				{:else}
+					<button
+						type="button"
+						id="{menuId}-item-{index}"
+						class="flex w-full items-center gap-2 text-left"
+						tabindex={item.disabled ? -1 : 0}
+						disabled={item.disabled || disabled}
+						aria-disabled={item.disabled || disabled}
+						onclick={() => handleItemClick(item, index)}
+						onkeydown={(e) => handleKeyDown(e, item, index)}
+						onfocus={() => handleFocus(index)}
+						onblur={handleBlur}
+					>
+						{#if item.icon}
+							<span class="text-lg" aria-hidden="true">{item.icon}</span>
+						{/if}
+						<span class="flex flex-col">
+							<span>{item.label}</span>
+							{#if item.description}
+								<span class="text-xs opacity-60">{item.description}</span>
+							{/if}
+						</span>
+					</button>
+				{/if}
+			</li>
+			{#if item.divider && index < items.length - 1}
+				<div class="divider my-1" role="separator" aria-orientation="horizontal"></div>
+			{/if}
+		{/each}
+	{/if}
+</ul>

--- a/hexawebshare/src/components/core/overlay-navigation/Menu.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Menu.svelte
@@ -141,11 +141,7 @@ SPDX-License-Identifier: MIT
 
 	// Compute item classes based on state
 	const getItemClasses = (item: MenuItem, index: number) =>
-		[
-			item.active && 'active',
-			item.disabled && 'disabled',
-			focusedIndex === index && 'focus'
-		]
+		[item.active && 'active', item.disabled && 'disabled', focusedIndex === index && 'focus']
 			.filter(Boolean)
 			.join(' ');
 


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements a fully functional Menu component (`Menu.svelte`) with comprehensive Storybook stories as requested in issue #77. The component follows Svelte 5 patterns with runes, uses DaisyUI styling statically, includes TypeScript interfaces, and provides full accessibility support with keyboard navigation.

**Key Features:**
- Programmatic rendering via `items` prop
- Slot-based content via `children` snippet
- Multiple variants: `default`, `bordered`, `compact`
- Size options: `sm`, `md`, `lg`
- Orientation support: `horizontal`, `vertical`
- Full keyboard navigation (Arrow keys, Home, End, Enter, Space)
- ARIA labels and roles for accessibility
- Support for icons, descriptions, dividers, active states, and disabled states
- Link support via `href` property

**Files Changed:**
- `src/components/core/overlay-navigation/Menu.svelte` - Component implementation (328 lines)
- `src/components/core/overlay-navigation/Menu.stories.svelte` - Comprehensive Storybook stories (193 lines)

Closes #77

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---


✅ PR Title:
```text
feat(core): implement Menu component with Storybook stories
```

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (feat/implement-menu-component)
- [x] My PR title starts with one of the approved types listed above (feat)
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (pnpm build, pnpm build-storybook)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes (no new dependencies)
- [x] For UI changes, I added Storybook stories demonstrating all variants and states
- [x] I linked related issues using keywords (Closes #77)
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #77

