### PR TITLE
feat(core): implement Steps component with Storybook stories

### DIFF
--- a/hexawebshare/src/components/core/overlay-navigation/Steps.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Steps.stories.svelte
@@ -1,0 +1,721 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Steps from './Steps.svelte';
+	import type { StepItem } from './Steps.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Overlay Navigation/Steps',
+		component: Steps,
+		tags: ['autodocs'],
+		argTypes: {
+			orientation: {
+				control: { type: 'select' },
+				options: ['horizontal', 'vertical']
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'primary',
+					'secondary',
+					'accent',
+					'neutral',
+					'info',
+					'success',
+					'warning',
+					'error'
+				]
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['xs', 'sm', 'md', 'lg']
+			},
+			clickable: { control: 'boolean' },
+			disabled: { control: 'boolean' },
+			loading: { control: 'boolean' }
+		}
+	});
+
+	// Sample step items
+	const sampleItems: StepItem[] = [
+		{ id: 1, label: 'Register', description: 'Create your account', completed: true },
+		{ id: 2, label: 'Choose Plan', description: 'Select a subscription', current: true },
+		{ id: 3, label: 'Payment', description: 'Complete payment' },
+		{ id: 4, label: 'Confirmation', description: 'Review and confirm' }
+	];
+
+	const simpleItems: StepItem[] = [
+		{ id: 1, label: 'Step 1', completed: true },
+		{ id: 2, label: 'Step 2', current: true },
+		{ id: 3, label: 'Step 3' }
+	];
+
+	const itemsWithIcons: StepItem[] = [
+		{ id: 1, label: 'Cart', description: 'Review items', icon: '🛒', completed: true },
+		{ id: 2, label: 'Shipping', description: 'Enter address', icon: '📦', current: true },
+		{ id: 3, label: 'Payment', description: 'Payment method', icon: '💳' },
+		{ id: 4, label: 'Confirm', description: 'Place order', icon: '✅' }
+	];
+
+	const registrationItemsWithIcons: StepItem[] = [
+		{ id: 1, label: 'Account', description: 'Create account', icon: '👤', completed: true },
+		{ id: 2, label: 'Plan', description: 'Choose plan', icon: '📋', current: true },
+		{ id: 3, label: 'Payment', description: 'Enter payment', icon: '💳' },
+		{ id: 4, label: 'Complete', description: 'All done', icon: '✨' }
+	];
+
+	const workflowItemsWithIcons: StepItem[] = [
+		{ id: 1, label: 'Start', description: 'Begin process', icon: '🚀', completed: true },
+		{ id: 2, label: 'Review', description: 'Check details', icon: '👀', completed: true },
+		{ id: 3, label: 'Approve', description: 'Get approval', icon: '✅', current: true },
+		{ id: 4, label: 'Complete', description: 'Finish task', icon: '🎉' }
+	];
+
+	const projectItemsWithIcons: StepItem[] = [
+		{ id: 1, label: 'Planning', description: 'Project planning', icon: '📝', completed: true },
+		{ id: 2, label: 'Design', description: 'Create design', icon: '🎨', completed: true },
+		{ id: 3, label: 'Development', description: 'Build features', icon: '⚙️', current: true },
+		{ id: 4, label: 'Testing', description: 'Test application', icon: '🧪' },
+		{ id: 5, label: 'Launch', description: 'Go live', icon: '🚀' }
+	];
+
+	const longItems: StepItem[] = [
+		{
+			id: 1,
+			label: 'Step One',
+			description: 'This is the first step in the process',
+			completed: true
+		},
+		{
+			id: 2,
+			label: 'Step Two',
+			description: 'This is the second step in the process',
+			completed: true
+		},
+		{
+			id: 3,
+			label: 'Step Three',
+			description: 'This is the third step in the process',
+			current: true
+		},
+		{ id: 4, label: 'Step Four', description: 'This is the fourth step in the process' },
+		{ id: 5, label: 'Step Five', description: 'This is the fifth step in the process' }
+	];
+
+	const itemsWithDisabled: StepItem[] = [
+		{ id: 1, label: 'Step 1', completed: true },
+		{ id: 2, label: 'Step 2', current: true },
+		{ id: 3, label: 'Step 3', disabled: true },
+		{ id: 4, label: 'Step 4' }
+	];
+
+	const itemsWithDisabledIcons: StepItem[] = [
+		{ id: 1, label: 'Start', icon: '🚀', completed: true },
+		{ id: 2, label: 'Process', icon: '⚙️', current: true },
+		{ id: 3, label: 'Blocked', icon: '🚫', disabled: true },
+		{ id: 4, label: 'Finish', icon: '🏁' }
+	];
+
+	const allCompletedItems: StepItem[] = [
+		{ id: 1, label: 'Step 1', completed: true },
+		{ id: 2, label: 'Step 2', completed: true },
+		{ id: 3, label: 'Step 3', completed: true },
+		{ id: 4, label: 'Step 4', completed: true, current: true }
+	];
+
+	const allCompletedItemsWithIcons: StepItem[] = [
+		{ id: 1, label: 'Start', icon: '🚀', completed: true },
+		{ id: 2, label: 'Progress', icon: '⚙️', completed: true },
+		{ id: 3, label: 'Review', icon: '👀', completed: true },
+		{ id: 4, label: 'Complete', icon: '✅', completed: true, current: true }
+	];
+
+	const itemsWithClickHandlers: StepItem[] = [
+		{
+			id: 1,
+			label: 'Step 1',
+			completed: true,
+			onclick: () => {
+				console.log('Step 1 clicked');
+			}
+		},
+		{
+			id: 2,
+			label: 'Step 2',
+			current: true,
+			onclick: () => {
+				console.log('Step 2 clicked');
+			}
+		},
+		{
+			id: 3,
+			label: 'Step 3',
+			onclick: () => {
+				console.log('Step 3 clicked');
+			}
+		}
+	];
+</script>
+
+<!-- Default Story -->
+<Story
+	name="Default"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<!-- Basic Examples -->
+<Story
+	name="Simple"
+	args={{
+		items: simpleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Long Path"
+	args={{
+		items: longItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<!-- Orientation Variants -->
+<Story
+	name="Horizontal"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Vertical"
+	args={{
+		items: sampleItems,
+		orientation: 'vertical',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<!-- Size Variants -->
+<Story
+	name="Extra Small"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'xs'
+	}}
+/>
+
+<Story
+	name="Extra Small with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'xs'
+	}}
+/>
+
+<Story
+	name="Small"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'sm'
+	}}
+/>
+
+<Story
+	name="Small with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'sm'
+	}}
+/>
+
+<Story
+	name="Medium"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Medium with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Large"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'lg'
+	}}
+/>
+
+<Story
+	name="Large with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'lg'
+	}}
+/>
+
+<!-- Variant Colors -->
+<Story
+	name="Primary"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Primary with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Secondary"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'secondary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Secondary with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'secondary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Accent"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'accent',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Accent with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'accent',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Neutral"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'neutral',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Neutral with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'neutral',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Info"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'info',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Info with Icons"
+	args={{
+		items: projectItemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'info',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Success"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'success',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Success with Icons"
+	args={{
+		items: workflowItemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'success',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Warning"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'warning',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Warning with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'warning',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Error"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'error',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Error with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'error',
+		size: 'md'
+	}}
+/>
+
+<!-- With Icons -->
+<Story
+	name="With Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="With Icons - Registration"
+	args={{
+		items: registrationItemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="With Icons - Workflow"
+	args={{
+		items: workflowItemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'success',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="With Icons - Project"
+	args={{
+		items: projectItemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'info',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="With Icons - Vertical"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'vertical',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="With Icons - Clickable"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		clickable: true
+	}}
+/>
+
+<!-- States -->
+<Story
+	name="Disabled"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		disabled: true
+	}}
+/>
+
+<Story
+	name="Disabled with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		disabled: true
+	}}
+/>
+
+<Story
+	name="Loading"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		loading: true
+	}}
+/>
+
+<Story
+	name="Loading with Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		loading: true
+	}}
+/>
+
+<Story
+	name="With Disabled Item"
+	args={{
+		items: itemsWithDisabled,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="With Disabled Item and Icons"
+	args={{
+		items: itemsWithDisabledIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="All Completed"
+	args={{
+		items: allCompletedItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="All Completed with Icons"
+	args={{
+		items: allCompletedItemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'success',
+		size: 'md'
+	}}
+/>
+
+<!-- Interactive Examples -->
+<Story
+	name="Clickable"
+	args={{
+		items: itemsWithClickHandlers,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		clickable: true
+	}}
+/>
+
+<Story
+	name="Clickable Vertical"
+	args={{
+		items: itemsWithClickHandlers,
+		orientation: 'vertical',
+		variant: 'primary',
+		size: 'md',
+		clickable: true
+	}}
+/>
+
+<!-- Edge Cases -->
+<Story
+	name="Single Item"
+	args={{
+		items: [{ id: 1, label: 'Step 1', current: true }],
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Two Items"
+	args={{
+		items: [
+			{ id: 1, label: 'Step 1', completed: true },
+			{ id: 2, label: 'Step 2', current: true }
+		],
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Three Items"
+	args={{
+		items: [
+			{ id: 1, label: 'Step 1', completed: true },
+			{ id: 2, label: 'Step 2', current: true },
+			{ id: 3, label: 'Step 3' }
+		],
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<!-- Accessibility Testing -->
+<Story
+	name="Accessibility - Full Example"
+	args={{
+		items: sampleItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		ariaLabel: 'Registration process steps'
+	}}
+/>
+
+<Story
+	name="Accessibility - With Icons"
+	args={{
+		items: itemsWithIcons,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		ariaLabel: 'Checkout process steps'
+	}}
+/>
+
+<Story
+	name="Accessibility - Clickable"
+	args={{
+		items: itemsWithClickHandlers,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md',
+		clickable: true,
+		ariaLabel: 'Interactive navigation steps'
+	}}
+/>
+
+<!-- Responsive Examples -->
+<Story
+	name="Responsive - Long Path"
+	args={{
+		items: longItems,
+		orientation: 'horizontal',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>
+
+<Story
+	name="Responsive - Vertical Mobile"
+	args={{
+		items: sampleItems,
+		orientation: 'vertical',
+		variant: 'primary',
+		size: 'md'
+	}}
+/>

--- a/hexawebshare/src/components/core/overlay-navigation/Steps.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Steps.svelte
@@ -2,3 +2,333 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script module lang="ts">
+	/**
+	 * Step item data structure
+	 */
+	export interface StepItem {
+		/**
+		 * Unique identifier for the step
+		 */
+		id?: string | number;
+		/**
+		 * Display label for the step
+		 */
+		label: string;
+		/**
+		 * Optional description for the step
+		 */
+		description?: string;
+		/**
+		 * Whether this step is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Whether this step is the current/active step
+		 * @default false
+		 */
+		current?: boolean;
+		/**
+		 * Whether this step is completed
+		 * @default false
+		 */
+		completed?: boolean;
+		/**
+		 * Optional icon to display in the step
+		 */
+		icon?: string;
+		/**
+		 * Callback when step is clicked
+		 */
+		onclick?: (item: StepItem, index: number) => void;
+	}
+</script>
+
+<script lang="ts">
+	/**
+	 * Props interface for the Steps component
+	 */
+	interface Props {
+		/**
+		 * Array of step items to display
+		 */
+		items: StepItem[];
+		/**
+		 * Orientation of the steps
+		 * @default 'horizontal'
+		 */
+		orientation?: 'horizontal' | 'vertical';
+		/**
+		 * Color variant for completed and current steps
+		 * @default 'primary'
+		 */
+		variant?:
+			| 'primary'
+			| 'secondary'
+			| 'accent'
+			| 'neutral'
+			| 'info'
+			| 'success'
+			| 'warning'
+			| 'error';
+		/**
+		 * Size variant of the steps
+		 * @default 'md'
+		 */
+		size?: 'xs' | 'sm' | 'md' | 'lg';
+		/**
+		 * Whether the steps are disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Whether the steps are in loading state
+		 * @default false
+		 */
+		loading?: boolean;
+		/**
+		 * Whether steps are clickable
+		 * @default false
+		 */
+		clickable?: boolean;
+		/**
+		 * Accessible label for the steps navigation
+		 * @default 'Steps navigation'
+		 */
+		ariaLabel?: string;
+		/**
+		 * ID of the element that labels this steps
+		 */
+		ariaLabelledby?: string;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		items,
+		orientation = 'horizontal',
+		variant = 'primary',
+		size = 'md',
+		disabled = false,
+		loading = false,
+		clickable = false,
+		ariaLabel = 'Steps navigation',
+		ariaLabelledby,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Generate unique ID for accessibility
+	const stepsId = crypto.randomUUID?.() ?? `steps-${Math.random().toString(36).slice(2, 9)}`;
+
+	// Computed container classes
+	let containerClasses = $derived(
+		[
+			'steps',
+			orientation === 'horizontal' && 'steps-horizontal',
+			orientation === 'vertical' && 'steps-vertical',
+			size === 'xs' && 'text-xs',
+			size === 'sm' && 'text-sm',
+			size === 'md' && 'text-base',
+			size === 'lg' && 'text-lg',
+			disabled && 'opacity-50 pointer-events-none',
+			loading && 'opacity-75',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Get step state
+	const getStepState = (item: StepItem, index: number): 'completed' | 'current' | 'pending' => {
+		if (item.completed) return 'completed';
+		if (item.current) return 'current';
+		// Auto-detect: if previous item is completed, this might be current
+		if (index > 0 && items[index - 1]?.completed && !item.completed && !item.current) {
+			// Check if this is the first non-completed step
+			const allPreviousCompleted = items.slice(0, index).every((i) => i.completed);
+			if (allPreviousCompleted) return 'current';
+		}
+		return 'pending';
+	};
+
+	// Get step classes based on variant and state
+	const getStepClasses = (item: StepItem, index: number): string => {
+		const isDisabled = item.disabled || disabled;
+		const state = getStepState(item, index);
+
+		return [
+			'step',
+			!isDisabled && state === 'completed' && variant === 'primary' && 'step-primary',
+			!isDisabled && state === 'completed' && variant === 'secondary' && 'step-secondary',
+			!isDisabled && state === 'completed' && variant === 'accent' && 'step-accent',
+			!isDisabled && state === 'completed' && variant === 'neutral' && 'step-neutral',
+			!isDisabled && state === 'completed' && variant === 'info' && 'step-info',
+			!isDisabled && state === 'completed' && variant === 'success' && 'step-success',
+			!isDisabled && state === 'completed' && variant === 'warning' && 'step-warning',
+			!isDisabled && state === 'completed' && variant === 'error' && 'step-error',
+			!isDisabled && state === 'current' && variant === 'primary' && 'step-primary',
+			!isDisabled && state === 'current' && variant === 'secondary' && 'step-secondary',
+			!isDisabled && state === 'current' && variant === 'accent' && 'step-accent',
+			!isDisabled && state === 'current' && variant === 'neutral' && 'step-neutral',
+			!isDisabled && state === 'current' && variant === 'info' && 'step-info',
+			!isDisabled && state === 'current' && variant === 'success' && 'step-success',
+			!isDisabled && state === 'current' && variant === 'warning' && 'step-warning',
+			!isDisabled && state === 'current' && variant === 'error' && 'step-error',
+			isDisabled && 'opacity-50 cursor-not-allowed'
+		]
+			.filter(Boolean)
+			.join(' ');
+	};
+
+	// Handle step click
+	const handleStepClick = (item: StepItem, index: number) => {
+		if (item.disabled || disabled || loading || !clickable) return;
+		item.onclick?.(item, index);
+	};
+
+	// Handle keyboard navigation
+	const handleKeyDown = (event: KeyboardEvent, item: StepItem, index: number) => {
+		if (item.disabled || disabled || loading || !clickable) return;
+
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			handleStepClick(item, index);
+		}
+	};
+
+	// Get ARIA attributes for step
+	const getStepAriaAttributes = (item: StepItem, index: number) => {
+		const isDisabled = item.disabled || disabled;
+		const state = getStepState(item, index);
+
+		return {
+			'aria-current': (state === 'current' ? 'step' : undefined) as 'step' | undefined,
+			'aria-disabled': isDisabled || false,
+			'aria-label': item.description ? `${item.label}: ${item.description}` : item.label,
+			role: 'listitem'
+		};
+	};
+</script>
+
+<ul
+	id={stepsId}
+	class={containerClasses}
+	role="list"
+	aria-label={ariaLabel}
+	aria-labelledby={ariaLabelledby}
+	{...props}
+>
+	{#each items as item, index (item.id ?? index)}
+		{@const stepState = getStepState(item, index)}
+		{@const stepClasses = getStepClasses(item, index)}
+		{@const ariaAttrs = getStepAriaAttributes(item, index)}
+		<li class={stepClasses} data-content={item.icon ? item.icon : undefined} {...ariaAttrs}>
+			{#if clickable && !item.disabled && !disabled && !loading}
+				<button
+					type="button"
+					class="step-button"
+					onclick={() => handleStepClick(item, index)}
+					onkeydown={(e) => handleKeyDown(e, item, index)}
+					aria-label={item.description ? `${item.label}: ${item.description}` : item.label}
+					aria-current={stepState === 'current' ? 'step' : undefined}
+					aria-disabled={item.disabled || disabled || false}
+					tabindex={item.disabled || disabled || loading ? -1 : 0}
+				>
+					<div class="step-text">
+						<span class="step-label">{item.label}</span>
+						{#if item.description}
+							<span class="step-description">{item.description}</span>
+						{/if}
+					</div>
+				</button>
+			{:else}
+				<div class="step-text">
+					<span class="step-label">{item.label}</span>
+					{#if item.description}
+						<span class="step-description">{item.description}</span>
+					{/if}
+				</div>
+			{/if}
+		</li>
+	{/each}
+</ul>
+
+<style>
+	.step-text {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		margin-top: 0.5rem;
+	}
+
+	.step-label {
+		font-weight: 500;
+		text-align: center;
+	}
+
+	.step-description {
+		font-size: 0.875rem;
+		opacity: 0.7;
+		text-align: center;
+	}
+
+	.step-button {
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		width: 100%;
+		cursor: pointer;
+		color: inherit;
+		font: inherit;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.step-button:hover:not(:disabled):not([aria-disabled='true']) {
+		opacity: 0.8;
+	}
+
+	.step-button:focus {
+		outline: 2px solid currentColor;
+		outline-offset: 2px;
+		border-radius: 0.25rem;
+	}
+
+	.step-button:disabled,
+	.step-button[aria-disabled='true'] {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.step[aria-disabled='true'] {
+		cursor: not-allowed;
+		pointer-events: none;
+	}
+
+	/* Ensure icons in step circles are properly sized */
+	.step[data-content]::after {
+		font-size: 1.25rem;
+		line-height: 1;
+	}
+
+	@media (max-width: 640px) {
+		.steps {
+			font-size: 0.875rem;
+		}
+
+		.step-description {
+			font-size: 0.75rem;
+		}
+
+		.step[data-content]::after {
+			font-size: 1rem;
+		}
+	}
+</style>

--- a/hexawebshare/src/lib/index.ts
+++ b/hexawebshare/src/lib/index.ts
@@ -1,2 +1,6 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+// Core / Overlay Navigation
+export { default as Steps } from '../components/core/overlay-navigation/Steps.svelte';
+export type { StepItem } from '../components/core/overlay-navigation/Steps.svelte';


### PR DESCRIPTION
# Pull Request

## 📄 Summary

Implements the Steps component (`hexawebshare/src/components/core/overlay-navigation/Steps.svelte`) as a fully functional Svelte 5 component with DaisyUI styling. This component provides a visual progress indicator for multi-step processes, supporting icons, various states (completed, current, pending), and both horizontal and vertical orientations.

The component follows all project conventions:
- Svelte 5 patterns with runes ($props, $derived, $state)
- TypeScript interfaces for all props
- DaisyUI classes used statically (no dynamic string interpolation)
- Comprehensive Storybook stories demonstrating all variants
- Full accessibility support (ARIA labels, keyboard navigation)
- Responsive design

**Key Features:**
- Horizontal and vertical orientations
- 8 color variants (primary, secondary, accent, neutral, info, success, warning, error)
- 4 size variants (xs, sm, md, lg)
- Icon support using DaisyUI's `data-content` attribute (icons display inside step circles)
- Clickable steps with keyboard navigation
- Disabled and loading states
- Individual step states (completed, current, pending)

Closes #76

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

✅ PR Title: `feat(core): implement Steps component with Storybook stories`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (feat/implement-steps-component)
- [x] My PR title starts with one of the approved types listed above (feat)
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings (0 errors, only pre-existing warnings)
- [x] I ran tests successfully (build and Storybook build passed)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes (no new dependencies)
- [x] For UI changes, I added screenshots and/or updated Storybook stories (comprehensive stories added)
- [x] I linked related issues using keywords like Closes #76
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

```text
Closes #76
```


