### PR TITLE
feat(core): implement separator component

### DIFF
--- a/hexawebshare/src/components/core/layout/Separator.stories.svelte
+++ b/hexawebshare/src/components/core/layout/Separator.stories.svelte
@@ -1,0 +1,170 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Separator from './Separator.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Layout/Separator',
+		component: Separator,
+		tags: ['autodocs'],
+		argTypes: {
+			orientation: {
+				control: { type: 'select' },
+				options: ['horizontal', 'vertical']
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'default',
+					'primary',
+					'secondary',
+					'accent',
+					'neutral',
+					'info',
+					'success',
+					'warning',
+					'error'
+				]
+			},
+			spacing: {
+				control: { type: 'select' },
+				options: ['none', 'xs', 'sm', 'md', 'lg', 'xl']
+			},
+			thickness: {
+				control: { type: 'select' },
+				options: ['1', '2', '4']
+			},
+			ariaLabel: { control: 'text' },
+			ariaHidden: { control: 'boolean' }
+		}
+	});
+</script>
+
+<!-- Default Stories -->
+<Story name="Default" />
+
+<Story name="Horizontal" args={{ orientation: 'horizontal' }} />
+
+<Story name="Vertical">
+	<div class="flex h-24 items-center gap-4">
+		<span>Left</span>
+		<Separator orientation="vertical" spacing="sm" />
+		<span>Right</span>
+	</div>
+</Story>
+
+<!-- Variant Stories -->
+<Story name="Primary" args={{ variant: 'primary' }} />
+
+<Story name="Secondary" args={{ variant: 'secondary' }} />
+
+<Story name="Accent" args={{ variant: 'accent' }} />
+
+<Story name="Neutral" args={{ variant: 'neutral' }} />
+
+<Story name="Info" args={{ variant: 'info' }} />
+
+<Story name="Success" args={{ variant: 'success' }} />
+
+<Story name="Warning" args={{ variant: 'warning' }} />
+
+<Story name="Error" args={{ variant: 'error' }} />
+
+<!-- Thickness Stories -->
+<Story name="Thickness 1px" args={{ thickness: '1' }} />
+
+<Story name="Thickness 2px" args={{ thickness: '2' }} />
+
+<Story name="Thickness 4px" args={{ thickness: '4' }} />
+
+<!-- Spacing Stories -->
+<Story name="Spacing None" args={{ spacing: 'none' }} />
+
+<Story name="Spacing Small" args={{ spacing: 'sm' }} />
+
+<Story name="Spacing Large" args={{ spacing: 'lg' }} />
+
+<!-- Accessibility -->
+<Story name="With Aria Label" args={{ ariaLabel: 'Content separator', ariaHidden: false }} />
+
+<!-- Usage Examples -->
+<Story name="Content Separation">
+	<div class="flex w-full flex-col gap-4">
+		<div class="bg-base-200 rounded-lg p-4">
+			<p>Section 1: Lorem ipsum dolor sit amet</p>
+		</div>
+		<Separator />
+		<div class="bg-base-200 rounded-lg p-4">
+			<p>Section 2: Consectetur adipiscing elit</p>
+		</div>
+		<Separator />
+		<div class="bg-base-200 rounded-lg p-4">
+			<p>Section 3: Sed do eiusmod tempor incididunt</p>
+		</div>
+	</div>
+</Story>
+
+<Story name="Vertical Navigation">
+	<div class="bg-base-200 flex h-16 items-center gap-4 rounded-lg p-4">
+		<span class="font-medium">Home</span>
+		<Separator orientation="vertical" spacing="sm" />
+		<span class="font-medium">Products</span>
+		<Separator orientation="vertical" spacing="sm" />
+		<span class="font-medium">About</span>
+		<Separator orientation="vertical" spacing="sm" />
+		<span class="font-medium">Contact</span>
+	</div>
+</Story>
+
+<!-- All Variants Showcase -->
+<Story name="All Variants">
+	<div class="flex w-full flex-col gap-4">
+		<Separator variant="default" />
+		<Separator variant="primary" />
+		<Separator variant="secondary" />
+		<Separator variant="accent" />
+		<Separator variant="neutral" />
+		<Separator variant="info" />
+		<Separator variant="success" />
+		<Separator variant="warning" />
+		<Separator variant="error" />
+	</div>
+</Story>
+
+<Story name="Thickness Comparison">
+	<div class="flex w-full flex-col gap-6">
+		<div>
+			<p class="mb-2 text-sm font-semibold">1px (Default)</p>
+			<Separator thickness="1" />
+		</div>
+		<div>
+			<p class="mb-2 text-sm font-semibold">2px</p>
+			<Separator thickness="2" />
+		</div>
+		<div>
+			<p class="mb-2 text-sm font-semibold">4px</p>
+			<Separator thickness="4" />
+		</div>
+	</div>
+</Story>
+
+<Story name="Vertical Thickness Comparison">
+	<div class="flex h-32 items-center gap-6">
+		<div class="flex h-full flex-col items-center gap-2">
+			<p class="text-xs font-semibold">1px</p>
+			<Separator orientation="vertical" thickness="1" spacing="sm" class="flex-1" />
+		</div>
+		<div class="flex h-full flex-col items-center gap-2">
+			<p class="text-xs font-semibold">2px</p>
+			<Separator orientation="vertical" thickness="2" spacing="sm" class="flex-1" />
+		</div>
+		<div class="flex h-full flex-col items-center gap-2">
+			<p class="text-xs font-semibold">4px</p>
+			<Separator orientation="vertical" thickness="4" spacing="sm" class="flex-1" />
+		</div>
+	</div>
+</Story>

--- a/hexawebshare/src/components/core/layout/Separator.svelte
+++ b/hexawebshare/src/components/core/layout/Separator.svelte
@@ -2,3 +2,206 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	/**
+	 * Color variant for the separator
+	 */
+	type SeparatorVariant =
+		| 'default'
+		| 'primary'
+		| 'secondary'
+		| 'accent'
+		| 'neutral'
+		| 'info'
+		| 'success'
+		| 'warning'
+		| 'error';
+
+	/**
+	 * Orientation of the separator
+	 */
+	type SeparatorOrientation = 'horizontal' | 'vertical';
+
+	/**
+	 * Spacing/margin size for the separator
+	 */
+	type SeparatorSpacing = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+	interface Props {
+		/**
+		 * Orientation of the separator
+		 * @default 'horizontal'
+		 */
+		orientation?: SeparatorOrientation;
+
+		/**
+		 * Color variant of the separator
+		 * @default 'default'
+		 */
+		variant?: SeparatorVariant;
+
+		/**
+		 * Spacing/margin size around the separator
+		 * @default 'md'
+		 */
+		spacing?: SeparatorSpacing;
+
+		/**
+		 * Thickness/size of the separator
+		 * @default '1'
+		 */
+		thickness?: '1' | '2' | '4';
+
+		/**
+		 * Accessible label for screen readers
+		 */
+		ariaLabel?: string;
+
+		/**
+		 * Whether the separator is purely decorative (hidden from screen readers)
+		 * @default true
+		 */
+		ariaHidden?: boolean;
+
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		orientation = 'horizontal',
+		variant = 'default',
+		spacing = 'md',
+		thickness = '1',
+		ariaLabel,
+		ariaHidden = true,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Static class mapping for orientation and width
+	let orientationClasses = $derived(
+		orientation === 'horizontal'
+			? 'w-full'
+			: 'h-full self-stretch flex-shrink-0'
+	);
+
+	// Static class mapping for thickness (horizontal uses border-top)
+	let thicknessClass = $derived(
+		thickness === '1'
+			? 'border-t'
+			: thickness === '2'
+				? 'border-t-2'
+				: thickness === '4'
+					? 'border-t-4'
+					: 'border-t'
+	);
+
+	// Static class mapping for vertical thickness (vertical uses border-left)
+	// The border itself creates the visual width
+	let verticalThicknessClass = $derived(
+		thickness === '1'
+			? 'border-l w-0'
+			: thickness === '2'
+				? 'border-l-2 w-0'
+				: thickness === '4'
+					? 'border-l-4 w-0'
+					: 'border-l w-0'
+	);
+
+	// Static class mapping for variant colors
+	let variantClass = $derived(
+		variant === 'default'
+			? 'border-base-300'
+			: variant === 'primary'
+				? 'border-primary'
+				: variant === 'secondary'
+					? 'border-secondary'
+					: variant === 'accent'
+						? 'border-accent'
+						: variant === 'neutral'
+							? 'border-neutral'
+							: variant === 'info'
+								? 'border-info'
+								: variant === 'success'
+									? 'border-success'
+									: variant === 'warning'
+										? 'border-warning'
+										: variant === 'error'
+											? 'border-error'
+											: 'border-base-300'
+	);
+
+	// Static class mapping for spacing
+	let spacingClass = $derived(
+		spacing === 'none'
+			? ''
+			: spacing === 'xs'
+				? orientation === 'horizontal'
+					? 'my-1'
+					: 'mx-1'
+				: spacing === 'sm'
+					? orientation === 'horizontal'
+						? 'my-2'
+						: 'mx-2'
+					: spacing === 'md'
+						? orientation === 'horizontal'
+							? 'my-4'
+							: 'mx-4'
+						: spacing === 'lg'
+							? orientation === 'horizontal'
+								? 'my-6'
+								: 'mx-6'
+							: spacing === 'xl'
+								? orientation === 'horizontal'
+									? 'my-8'
+									: 'mx-8'
+								: orientation === 'horizontal'
+									? 'my-4'
+									: 'mx-4'
+	);
+
+	// Combine all classes - ensure all properties are reactive
+	let separatorClasses = $derived(
+		[
+			// Thickness class based on orientation
+			orientation === 'horizontal' ? thicknessClass : verticalThicknessClass,
+			// Orientation-specific classes
+			orientationClasses,
+			// Variant color class
+			variantClass,
+			// Spacing class
+			spacingClass,
+			// Custom classes
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	const computedAriaHidden = $derived(ariaLabel ? false : ariaHidden);
+	const role = $derived(computedAriaHidden ? undefined : 'separator');
+	const ariaOrientation = $derived(computedAriaHidden ? undefined : orientation);
+</script>
+
+{#if orientation === 'horizontal'}
+	<hr
+		class="{separatorClasses} border-b-0 border-l-0 border-r-0"
+		{role}
+		aria-orientation={ariaOrientation}
+		aria-hidden={computedAriaHidden}
+		aria-label={ariaLabel}
+		{...props}
+	/>
+{:else}
+	<div
+		class={separatorClasses}
+		{role}
+		aria-orientation={ariaOrientation}
+		aria-hidden={computedAriaHidden}
+		aria-label={ariaLabel}
+		{...props}
+	></div>
+{/if}

--- a/hexawebshare/src/components/core/layout/Separator.svelte
+++ b/hexawebshare/src/components/core/layout/Separator.svelte
@@ -83,9 +83,7 @@ SPDX-License-Identifier: MIT
 
 	// Static class mapping for orientation and width
 	let orientationClasses = $derived(
-		orientation === 'horizontal'
-			? 'w-full'
-			: 'h-full self-stretch flex-shrink-0'
+		orientation === 'horizontal' ? 'w-full' : 'h-full self-stretch flex-shrink-0'
 	);
 
 	// Static class mapping for thickness (horizontal uses border-top)
@@ -188,7 +186,7 @@ SPDX-License-Identifier: MIT
 
 {#if orientation === 'horizontal'}
 	<hr
-		class="{separatorClasses} border-b-0 border-l-0 border-r-0"
+		class="{separatorClasses} border-r-0 border-b-0 border-l-0"
 		{role}
 		aria-orientation={ariaOrientation}
 		aria-hidden={computedAriaHidden}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements the Separator component as specified in issue #102. The component provides a flexible separator element that can be used horizontally or vertically with various styling options including color variants, spacing, and thickness controls.

**Key Features:**
- Horizontal and vertical orientations
- 9 color variants (default, primary, secondary, accent, neutral, info, success, warning, error)
- 6 spacing options (none, xs, sm, md, lg, xl)
- 3 thickness options (1px, 2px, 4px)
- Full accessibility support with ARIA attributes
- Comprehensive Storybook stories demonstrating all variants and use cases

**Implementation Details:**
- Uses Svelte 5 runes ($props, $derived) for reactivity
- Follows DaisyUI styling patterns with static classes
- TypeScript interfaces for all props
- Semantic HTML (hr for horizontal, div for vertical)
- Proper border handling for both orientations

Closes #102

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

✅ PR Title: `feat(Separator): implement Separator component with Storybook stories`

This follows the conventional commits format with:
- Type: `feat` (new feature)
- Scope: `Separator`
- Description: Clear and descriptive

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: `feat/implement-separator-component`
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (Prettier format applied)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (build and Storybook build passed)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes (no changes needed)
- [x] For UI changes, I added Storybook stories demonstrating all variants
- [x] I linked related issues using keywords: Closes #102
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #102


