### PR TITLE
feat(core): add RadioGroup component with Storybook stories

### DIFF
--- a/hexawebshare/src/components/core/forms/RadioGroup.stories.svelte
+++ b/hexawebshare/src/components/core/forms/RadioGroup.stories.svelte
@@ -1,0 +1,358 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import RadioGroup from './RadioGroup.svelte';
+	import { fn } from 'storybook/test';
+
+	const { Story } = defineMeta({
+		title: 'Core/Forms/RadioGroup',
+		component: RadioGroup,
+		tags: ['autodocs'],
+		argTypes: {
+			variant: {
+				control: { type: 'select' },
+				options: ['primary', 'secondary', 'accent', 'info', 'success', 'warning', 'error']
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['xs', 'sm', 'md', 'lg']
+			},
+			disabled: { control: 'boolean' },
+			required: { control: 'boolean' },
+			loading: { control: 'boolean' },
+			label: { control: 'text' },
+			error: { control: 'text' },
+			helpText: { control: 'text' },
+			value: { control: 'text' }
+		},
+		args: {
+			name: 'radio-group',
+			options: ['Option 1', 'Option 2', 'Option 3'],
+			onchange: fn()
+		}
+	});
+</script>
+
+<!-- Default Story -->
+<Story
+	name="Default"
+	args={{
+		name: 'default-group',
+		label: 'Select an option',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<!-- With Label -->
+<Story
+	name="With Label"
+	args={{
+		name: 'label-group',
+		label: 'Choose your favorite fruit',
+		options: ['Apple', 'Banana', 'Cherry', 'Date']
+	}}
+/>
+
+<!-- With Value (Pre-selected) -->
+<Story
+	name="With Value"
+	args={{
+		name: 'value-group',
+		label: 'Select your country',
+		value: 'canada',
+		options: [
+			{ value: 'usa', label: 'United States' },
+			{ value: 'canada', label: 'Canada' },
+			{ value: 'mexico', label: 'Mexico' }
+		]
+	}}
+/>
+
+<!-- With Help Text -->
+<Story
+	name="With Help Text"
+	args={{
+		name: 'help-group',
+		label: 'Payment Method',
+		options: ['Credit Card', 'Bank Transfer', 'Cash'],
+		helpText: 'Select your preferred payment method'
+	}}
+/>
+
+<!-- Required -->
+<Story
+	name="Required"
+	args={{
+		name: 'required-group',
+		label: 'Gender',
+		required: true,
+		options: ['Male', 'Female', 'Other']
+	}}
+/>
+
+<!-- With Error -->
+<Story
+	name="With Error"
+	args={{
+		name: 'error-group',
+		label: 'Subscription Plan',
+		options: ['Free', 'Pro', 'Enterprise'],
+		error: 'Please select a subscription plan'
+	}}
+/>
+
+<!-- Disabled -->
+<Story
+	name="Disabled"
+	args={{
+		name: 'disabled-group',
+		label: 'Disabled Group',
+		disabled: true,
+		value: 'option1',
+		options: [
+			{ value: 'option1', label: 'Option 1' },
+			{ value: 'option2', label: 'Option 2' },
+			{ value: 'option3', label: 'Option 3' }
+		]
+	}}
+/>
+
+<!-- Variant Stories -->
+<Story
+	name="Primary"
+	args={{
+		name: 'primary-group',
+		label: 'Primary Variant',
+		variant: 'primary',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Secondary"
+	args={{
+		name: 'secondary-group',
+		label: 'Secondary Variant',
+		variant: 'secondary',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Accent"
+	args={{
+		name: 'accent-group',
+		label: 'Accent Variant',
+		variant: 'accent',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Success"
+	args={{
+		name: 'success-group',
+		label: 'Success Variant',
+		variant: 'success',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Warning"
+	args={{
+		name: 'warning-group',
+		label: 'Warning Variant',
+		variant: 'warning',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Info"
+	args={{
+		name: 'info-group',
+		label: 'Info Variant',
+		variant: 'info',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Error Variant"
+	args={{
+		name: 'error-variant-group',
+		label: 'Error Variant',
+		variant: 'error',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<!-- Size Stories -->
+<Story
+	name="Extra Small"
+	args={{
+		name: 'xs-group',
+		label: 'Extra Small Size',
+		size: 'xs',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Small"
+	args={{
+		name: 'sm-group',
+		label: 'Small Size',
+		size: 'sm',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Medium"
+	args={{
+		name: 'md-group',
+		label: 'Medium Size (Default)',
+		size: 'md',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="Large"
+	args={{
+		name: 'lg-group',
+		label: 'Large Size',
+		size: 'lg',
+		value: 'option1',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<!-- With Disabled Options -->
+<Story
+	name="With Disabled Options"
+	args={{
+		name: 'disabled-options-group',
+		label: 'Some Options Disabled',
+		options: [
+			{ value: 'opt1', label: 'Available Option 1' },
+			{ value: 'opt2', label: 'Disabled Option', disabled: true },
+			{ value: 'opt3', label: 'Available Option 2' },
+			{ value: 'opt4', label: 'Disabled Option 2', disabled: true }
+		]
+	}}
+/>
+
+<!-- Loading -->
+<Story
+	name="Loading"
+	args={{
+		name: 'loading-group',
+		label: 'Loading Radio Group',
+		loading: true,
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<!-- Loading with Selection -->
+<Story
+	name="Loading with Selection"
+	args={{
+		name: 'loading-selected-group',
+		label: 'Loading with Pre-selected',
+		loading: true,
+		value: 'option2',
+		options: [
+			{ value: 'option1', label: 'Option 1' },
+			{ value: 'option2', label: 'Option 2' },
+			{ value: 'option3', label: 'Option 3' }
+		]
+	}}
+/>
+
+<!-- Accessibility Stories -->
+<Story
+	name="ARIA Label Only"
+	args={{
+		name: 'aria-label-group',
+		ariaLabel: 'Radio group without visible label',
+		options: ['Option 1', 'Option 2', 'Option 3']
+	}}
+/>
+
+<Story
+	name="ARIA Describedby"
+	args={{
+		name: 'aria-describedby-group',
+		label: 'Radio Group with Description',
+		ariaDescribedby: 'radio-help',
+		helpText: 'This is helpful information for screen readers'
+	}}
+/>
+
+<Story
+	name="Accessibility Testing"
+	args={{
+		name: 'accessibility-test-group',
+		label: 'Accessibility Test Group',
+		required: true,
+		helpText: 'Use keyboard navigation (Arrow keys) to move between options'
+	}}
+/>
+
+<!-- Form Integration Example -->
+<Story name="Form Example">
+	<div class="bg-base-200 max-w-md rounded-lg p-6">
+		<h2 class="mb-4 text-xl font-bold">Registration Form</h2>
+		<div class="space-y-4">
+			<RadioGroup
+				name="form-gender"
+				label="Gender"
+				required={true}
+				variant="primary"
+				options={['Male', 'Female', 'Other', 'Prefer not to say']}
+			/>
+			<RadioGroup
+				name="form-notification"
+				label="Notification Preferences"
+				variant="primary"
+				value="email"
+				helpText="How would you like to receive updates?"
+				options={[
+					{ value: 'email', label: 'Email' },
+					{ value: 'sms', label: 'SMS' },
+					{ value: 'push', label: 'Push Notifications' },
+					{ value: 'none', label: 'No notifications' }
+				]}
+			/>
+			<RadioGroup
+				name="form-plan"
+				label="Subscription Plan"
+				required={true}
+				variant="primary"
+				options={[
+					{ value: 'free', label: 'Free - Basic features' },
+					{ value: 'pro', label: 'Pro - $9.99/month' },
+					{ value: 'enterprise', label: 'Enterprise - Contact us' }
+				]}
+			/>
+			<button class="btn btn-primary mt-4 w-full">Submit</button>
+		</div>
+	</div>
+</Story>

--- a/hexawebshare/src/components/core/forms/RadioGroup.svelte
+++ b/hexawebshare/src/components/core/forms/RadioGroup.svelte
@@ -56,20 +56,20 @@ SPDX-License-Identifier: MIT
 		 * @default false
 		 */
 		disabled?: boolean;
-	/**
-	 * Whether the radio group is required
-	 * @default false
-	 */
-	required?: boolean;
-	/**
-	 * Whether the radio group is in loading state
-	 * @default false
-	 */
-	loading?: boolean;
-	/**
-	 * HTML id attribute
-	 */
-	id?: string;
+		/**
+		 * Whether the radio group is required
+		 * @default false
+		 */
+		required?: boolean;
+		/**
+		 * Whether the radio group is in loading state
+		 * @default false
+		 */
+		loading?: boolean;
+		/**
+		 * HTML id attribute
+		 */
+		id?: string;
 		/**
 		 * Accessible label for screen readers
 		 */
@@ -195,8 +195,13 @@ SPDX-License-Identifier: MIT
 		class="relative flex flex-col gap-2"
 	>
 		{#if loading}
-			<div class="absolute top-0 left-0 z-10 flex h-full w-full items-center justify-center bg-base-100/80 rounded-lg" role="status" aria-label="Loading">
-				<span class="loading loading-spinner {loadingSizeClass} text-primary" aria-hidden="true"></span>
+			<div
+				class="bg-base-100/80 absolute top-0 left-0 z-10 flex h-full w-full items-center justify-center rounded-lg"
+				role="status"
+				aria-label="Loading"
+			>
+				<span class="loading loading-spinner {loadingSizeClass} text-primary" aria-hidden="true"
+				></span>
 			</div>
 		{/if}
 		{#each normalizedOptions as option, index (option.value)}

--- a/hexawebshare/src/components/core/forms/RadioGroup.svelte
+++ b/hexawebshare/src/components/core/forms/RadioGroup.svelte
@@ -2,3 +2,235 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	/**
+	 * Option type for radio options
+	 */
+	export type RadioOption = {
+		value: string;
+		label: string;
+		disabled?: boolean;
+	};
+
+	/**
+	 * Props interface for the RadioGroup component
+	 */
+	interface Props {
+		/**
+		 * Selected value (controlled)
+		 */
+		value?: string;
+		/**
+		 * Options array - can be array of strings or array of RadioOption objects
+		 */
+		options: string[] | RadioOption[];
+		/**
+		 * Color variant of the radio buttons
+		 * @default undefined (default DaisyUI radio style)
+		 */
+		variant?: 'primary' | 'secondary' | 'accent' | 'info' | 'success' | 'warning' | 'error';
+		/**
+		 * Size of the radio buttons
+		 * @default 'md'
+		 */
+		size?: 'xs' | 'sm' | 'md' | 'lg';
+		/**
+		 * HTML name attribute for form submission (required for radio groups)
+		 */
+		name: string;
+		/**
+		 * Label text for the radio group
+		 */
+		label?: string;
+		/**
+		 * Error message to display
+		 */
+		error?: string;
+		/**
+		 * Helper text or description
+		 */
+		helpText?: string;
+		/**
+		 * Whether the radio group is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+	/**
+	 * Whether the radio group is required
+	 * @default false
+	 */
+	required?: boolean;
+	/**
+	 * Whether the radio group is in loading state
+	 * @default false
+	 */
+	loading?: boolean;
+	/**
+	 * HTML id attribute
+	 */
+	id?: string;
+		/**
+		 * Accessible label for screen readers
+		 */
+		ariaLabel?: string;
+		/**
+		 * ARIA describedby attribute
+		 */
+		ariaDescribedby?: string;
+		/**
+		 * Change event handler
+		 */
+		onchange?: (event: Event) => void;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		value,
+		options,
+		variant,
+		size = 'md',
+		name,
+		label,
+		error,
+		helpText,
+		disabled = false,
+		required = false,
+		loading = false,
+		id,
+		ariaLabel,
+		ariaDescribedby,
+		onchange,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Generate unique ID if not provided
+	let groupId = $derived(id || `radio-group-${Math.random().toString(36).substr(2, 9)}`);
+	let labelId = $derived(`${groupId}-label`);
+	let errorId = $derived(`${groupId}-error`);
+	let helpTextId = $derived(`${groupId}-help`);
+
+	// Normalize options to RadioOption format
+	let normalizedOptions = $derived(
+		options.map((option) => {
+			if (typeof option === 'string') {
+				return { value: option, label: option, disabled: false };
+			}
+			return option;
+		})
+	);
+
+	// Check if there's an error
+	let hasError = $derived(error !== undefined && error !== '');
+
+	// Radio classes using static DaisyUI classes for JIT compilation
+	// Apply error variant automatically when there's an error
+	let radioClasses = $derived(
+		[
+			'radio',
+			// Error state overrides variant
+			hasError && 'radio-error',
+			!hasError && variant === 'primary' && 'radio-primary',
+			!hasError && variant === 'secondary' && 'radio-secondary',
+			!hasError && variant === 'accent' && 'radio-accent',
+			!hasError && variant === 'info' && 'radio-info',
+			!hasError && variant === 'success' && 'radio-success',
+			!hasError && variant === 'warning' && 'radio-warning',
+			!hasError && variant === 'error' && 'radio-error',
+			size === 'xs' && 'radio-xs',
+			size === 'sm' && 'radio-sm',
+			size === 'md' && 'radio-md',
+			size === 'lg' && 'radio-lg'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Determine describedby for accessibility
+	let describedBy = $derived(
+		[ariaDescribedby, error && errorId, helpText && !error && helpTextId]
+			.filter(Boolean)
+			.join(' ') || undefined
+	);
+
+	// Loading spinner size classes
+	let loadingSizeClass = $derived(
+		size === 'xs'
+			? 'loading-xs'
+			: size === 'sm'
+				? 'loading-sm'
+				: size === 'lg'
+					? 'loading-lg'
+					: 'loading-md'
+	);
+
+	// Check if radio group should be disabled (either disabled prop or loading)
+	let isDisabled = $derived(disabled || loading);
+</script>
+
+<div class="form-control w-full {className}">
+	{#if label}
+		<label id={labelId} class="label">
+			<span class="label-text">
+				{label}
+				{#if required}
+					<span class="text-error ml-1" aria-label="required">*</span>
+				{/if}
+			</span>
+		</label>
+	{/if}
+
+	<div
+		role="radiogroup"
+		aria-labelledby={label ? labelId : undefined}
+		aria-label={!label ? ariaLabel : undefined}
+		aria-describedby={describedBy}
+		aria-required={required}
+		aria-invalid={hasError ? 'true' : undefined}
+		aria-busy={loading}
+		class="relative flex flex-col gap-2"
+	>
+		{#if loading}
+			<div class="absolute top-0 left-0 z-10 flex h-full w-full items-center justify-center bg-base-100/80 rounded-lg" role="status" aria-label="Loading">
+				<span class="loading loading-spinner {loadingSizeClass} text-primary" aria-hidden="true"></span>
+			</div>
+		{/if}
+		{#each normalizedOptions as option, index (option.value)}
+			{@const optionId = `${groupId}-option-${index}`}
+			<label for={optionId} class="label cursor-pointer justify-start gap-4 pr-6">
+				<input
+					id={optionId}
+					type="radio"
+					{name}
+					value={option.value}
+					checked={value === option.value}
+					disabled={isDisabled || option.disabled}
+					class={radioClasses}
+					{onchange}
+					{...props}
+				/>
+				<span class="label-text">{option.label}</span>
+			</label>
+		{/each}
+	</div>
+
+	{#if hasError}
+		<div id={errorId} class="label">
+			<span class="label-text-alt text-error" role="alert" aria-live="polite">
+				{error}
+			</span>
+		</div>
+	{/if}
+
+	{#if helpText && !hasError}
+		<div id={helpTextId} class="label">
+			<span class="label-text-alt text-base-content/70">
+				{helpText}
+			</span>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Pull Request

### 📄 Summary
This PR implements the RadioGroup component for the core/forms category. The component was previously an empty skeleton file and is now fully functional with Svelte 5 runes, TypeScript interfaces, DaisyUI styling, and comprehensive Storybook stories.

**Key Features:**
- Radio button group with support for string or object options
- Full accessibility support (ARIA labels, keyboard navigation, role attributes)
- Loading state with spinner overlay
- Error and help text display
- Responsive design (vertical layout for mobile-friendly UX)
- 20+ Storybook stories covering all variants, sizes, and states
- Proper required indicator logic (asterisk on label when present)
- Support for disabled individual options within the group

**Closes #116**

### 🧩 Affected Module(s)
Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

### 🏷️ Suggested Labels
- `type:feature` - New feature
- `module:source` - Source code changes
- `priority:medium` - Normal importance

### ✏️ PR Title Format
✅ **PR Title:** `feat(core): add RadioGroup component with Storybook stories`

### ✅ Checklist
Before submitting, make sure you've completed the following:

- [x] My branch name follows format: `feat/add-radio-group-component`
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (Storybook stories verified)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes
- [x] For UI changes, I added Storybook stories covering all variants and states
- [x] I linked related issues using keywords like `Closes #116`
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

### 🔗 Related Issues
**Closes #116**

---

### 💬 Additional Notes

#### Testing Instructions

**Storybook:** Run `pnpm storybook` and navigate to `Core/Forms/RadioGroup`

**Verify Stories:** Check all stories render correctly:
- Default, With Label, With Value
- All 7 variants (Primary, Secondary, Accent, Info, Success, Warning, Error)
- All 4 sizes (xs, sm, md, lg)
- State stories (Required, Disabled, With Error, With Help Text, Loading, With Disabled Options)
- Accessibility stories (ARIA Label Only, ARIA Describedby, Accessibility Testing)
- Form Example

**Functionality:**
- Test radio button selection (only one can be selected at a time)
- Verify disabled state disables all options
- Check loading state shows spinner and disables interaction
- Test error message display
- Test help text display (hidden when error is present)
- Verify required indicator appears on label
- Test keyboard navigation (Arrow keys move between options)
- Check responsive behavior (vertical layout on all screen sizes)

#### Component Details
- **Location:** `hexawebshare/src/components/core/forms/RadioGroup.svelte`
- **Stories:** `hexawebshare/src/components/core/forms/RadioGroup.stories.svelte`
- **Pattern:** Follows Svelte 5 runes pattern ($props, $derived)
- **Styling:** Uses DaisyUI static classes (no dynamic string interpolation)
- **Accessibility:** WCAG compliant with proper ARIA attributes (role="radiogroup", aria-required, aria-invalid, aria-busy)
- **Type Export:** `RadioOption` type exported for TypeScript support

#### Files Changed
- `hexawebshare/src/components/core/forms/RadioGroup.svelte` (237 lines - component implementation)
- `hexawebshare/src/components/core/forms/RadioGroup.stories.svelte` (359 lines - Storybook stories)