### PR TITLE
feat(Tag): implement Tag component with Storybook stories

### DIFF
--- a/hexawebshare/src/components/core/media/Tag.stories.svelte
+++ b/hexawebshare/src/components/core/media/Tag.stories.svelte
@@ -1,0 +1,126 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import Tag from './Tag.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Core/Media/Tag',
+		component: Tag,
+		tags: ['autodocs'],
+		argTypes: {
+			label: {
+				control: 'text',
+				description: 'Tag label text'
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'primary',
+					'secondary',
+					'accent',
+					'neutral',
+					'info',
+					'success',
+					'warning',
+					'error',
+					'ghost'
+				],
+				description: 'Color variant of the tag'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['xs', 'sm', 'md', 'lg', 'xl'],
+				description: 'Size of the tag'
+			},
+			outline: {
+				control: 'boolean',
+				description: 'Outline style tag'
+			},
+			soft: {
+				control: 'boolean',
+				description: 'Soft/muted background style'
+			},
+			dash: {
+				control: 'boolean',
+				description: 'Dashed border style'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Disable the tag'
+			},
+			loading: {
+				control: 'boolean',
+				description: 'Show loading spinner in the tag'
+			},
+			removable: {
+				control: 'boolean',
+				description: 'Show remove button on the tag'
+			},
+			clickable: {
+				control: 'boolean',
+				description: 'Make the tag clickable'
+			}
+		},
+		args: {
+			label: 'Tag',
+			size: 'md',
+			variant: 'neutral',
+			outline: false,
+			soft: false,
+			dash: false,
+			disabled: false,
+			loading: false,
+			removable: false,
+			clickable: false
+		}
+	});
+</script>
+
+<!-- Default -->
+<Story name="Default" args={{ label: 'Tag', variant: 'neutral', size: 'md' }} />
+
+<!-- Playground -->
+<Story
+	name="Playground"
+	args={{
+		label: 'Interactive Tag',
+		size: 'md',
+		variant: 'primary',
+		outline: false,
+		soft: false,
+		dash: false,
+		disabled: false,
+		loading: false,
+		removable: false,
+		clickable: false
+	}}
+/>
+
+<!-- Variants -->
+<Story name="Primary" args={{ label: 'Primary', variant: 'primary' }} />
+<Story name="Success" args={{ label: 'Success', variant: 'success' }} />
+<Story name="Warning" args={{ label: 'Warning', variant: 'warning' }} />
+<Story name="Error" args={{ label: 'Error', variant: 'error' }} />
+<Story name="Info" args={{ label: 'Info', variant: 'info' }} />
+
+<!-- Sizes -->
+<Story name="Extra Small" args={{ label: 'XS Tag', size: 'xs', variant: 'primary' }} />
+<Story name="Large" args={{ label: 'Large Tag', size: 'lg', variant: 'primary' }} />
+<Story name="Extra Large" args={{ label: 'XL Tag', size: 'xl', variant: 'primary' }} />
+
+<!-- Styles -->
+<Story name="Outline" args={{ label: 'Outline Tag', variant: 'primary', outline: true }} />
+<Story name="Soft" args={{ label: 'Soft Tag', variant: 'primary', soft: true }} />
+<Story name="Dash" args={{ label: 'Dash Tag', variant: 'primary', dash: true }} />
+
+<!-- States -->
+<Story name="Disabled" args={{ label: 'Disabled', variant: 'primary', disabled: true }} />
+<Story name="Loading" args={{ label: 'Loading', variant: 'info', loading: true }} />
+
+<!-- Interactive -->
+<Story name="Removable" args={{ label: 'Click × to remove', variant: 'info', removable: true }} />
+<Story name="Clickable" args={{ label: 'Clickable', variant: 'success', clickable: true }} />

--- a/hexawebshare/src/components/core/media/Tag.svelte
+++ b/hexawebshare/src/components/core/media/Tag.svelte
@@ -2,3 +2,242 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Props interface for the Tag component
+	 */
+	interface Props {
+		/**
+		 * Tag label text
+		 */
+		label: string;
+		/**
+		 * Color variant of the tag
+		 * @default 'neutral'
+		 */
+		variant?:
+			| 'primary'
+			| 'secondary'
+			| 'accent'
+			| 'neutral'
+			| 'info'
+			| 'success'
+			| 'warning'
+			| 'error'
+			| 'ghost';
+		/**
+		 * Size of the tag
+		 * @default 'md'
+		 */
+		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+		/**
+		 * Outline style tag
+		 * @default false
+		 */
+		outline?: boolean;
+		/**
+		 * Soft/muted background style
+		 * @default false
+		 */
+		soft?: boolean;
+		/**
+		 * Dash/dashed border style
+		 * @default false
+		 */
+		dash?: boolean;
+		/**
+		 * Whether the tag is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Whether the tag is in loading state
+		 * @default false
+		 */
+		loading?: boolean;
+		/**
+		 * Show remove button (×) on the tag
+		 * @default false
+		 */
+		removable?: boolean;
+		/**
+		 * Callback when remove button is clicked
+		 */
+		onRemove?: () => void;
+		/**
+		 * Make the tag clickable
+		 * @default false
+		 */
+		clickable?: boolean;
+		/**
+		 * Callback when tag is clicked (only works if clickable is true)
+		 */
+		onclick?: () => void;
+		/**
+		 * Icon snippet to display before the label
+		 */
+		icon?: Snippet;
+		/**
+		 * Accessible label for screen readers
+		 */
+		ariaLabel?: string;
+		/**
+		 * Hide tag from screen readers (decorative tags)
+		 * @default false
+		 */
+		ariaHidden?: boolean;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		label,
+		variant = 'neutral',
+		size = 'md',
+		outline = false,
+		soft = false,
+		dash = false,
+		disabled = false,
+		loading = false,
+		removable = false,
+		onRemove,
+		clickable = false,
+		onclick,
+		icon,
+		ariaLabel,
+		ariaHidden = false,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Internal visibility state for self-removing
+	let isVisible = $state(true);
+
+	// Tag classes using static DaisyUI classes
+	let tagClasses = $derived(
+		[
+			'badge',
+			'inline-flex',
+			'items-center',
+			'gap-1',
+			variant === 'primary' && 'badge-primary',
+			variant === 'secondary' && 'badge-secondary',
+			variant === 'accent' && 'badge-accent',
+			variant === 'neutral' && 'badge-neutral',
+			variant === 'info' && 'badge-info',
+			variant === 'success' && 'badge-success',
+			variant === 'warning' && 'badge-warning',
+			variant === 'error' && 'badge-error',
+			variant === 'ghost' && 'badge-ghost',
+			size === 'xs' && 'badge-xs',
+			size === 'sm' && 'badge-sm',
+			size === 'md' && 'badge-md',
+			size === 'lg' && 'badge-lg',
+			size === 'xl' && 'badge-xl',
+			outline && 'badge-outline',
+			soft && 'badge-soft',
+			dash && 'badge-dash',
+			disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+			clickable && !disabled && 'cursor-pointer hover:opacity-80 transition-opacity',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Accessibility: Determine if tag is decorative or semantic
+	let isDecorative = $derived(ariaHidden || (!ariaLabel && true));
+
+	// Loading spinner size based on tag size
+	let spinnerSizeClass = $derived(
+		size === 'xs'
+			? 'loading-xs'
+			: size === 'sm'
+				? 'loading-sm'
+				: size === 'md'
+					? 'loading-sm'
+					: size === 'lg'
+						? 'loading-md'
+						: 'loading-md'
+	);
+
+	// Close button size based on tag size
+	let closeBtnSizeClass = $derived(
+		size === 'xs'
+			? 'text-xs'
+			: size === 'sm'
+				? 'text-xs'
+				: size === 'md'
+					? 'text-sm'
+					: size === 'lg'
+						? 'text-base'
+						: 'text-lg'
+	);
+
+	// Handle tag click
+	function handleClick() {
+		if (clickable && !disabled) {
+			if (onclick) onclick();
+		}
+	}
+
+	// Handle remove button click - hides the tag
+	function handleRemove(event: MouseEvent) {
+		event.stopPropagation();
+		if (!disabled) {
+			isVisible = false;
+			if (onRemove) onRemove();
+		}
+	}
+
+	// Handle keyboard navigation
+	function handleKeyDown(event: KeyboardEvent) {
+		if (disabled) return;
+
+		if (clickable && (event.key === 'Enter' || event.key === ' ')) {
+			event.preventDefault();
+			if (onclick) onclick();
+		}
+	}
+</script>
+
+{#if isVisible}
+	<span
+		class={tagClasses}
+		aria-label={ariaLabel}
+		aria-hidden={isDecorative}
+		aria-disabled={disabled}
+		aria-busy={loading}
+		role={clickable ? 'button' : isDecorative ? undefined : 'status'}
+		tabindex={clickable && !disabled ? 0 : undefined}
+		onclick={handleClick}
+		onkeydown={handleKeyDown}
+		{...props}
+	>
+		{#if loading}
+			<span class="loading loading-spinner {spinnerSizeClass}" aria-hidden="true"></span>
+		{/if}
+		{#if icon}
+			<span class="inline-flex items-center" aria-hidden="true">
+				{@render icon()}
+			</span>
+		{/if}
+		{label}
+		{#if removable}
+			<button
+				type="button"
+				class="-mr-1 ml-1 inline-flex items-center justify-center rounded-full p-0.5 opacity-70 transition-all hover:bg-current/20 hover:opacity-100 focus:outline-none {closeBtnSizeClass}"
+				onclick={handleRemove}
+				aria-label="Remove tag"
+				{disabled}
+			>
+				✕
+			</button>
+		{/if}
+	</span>
+{/if}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

Implementing the **Tag** component for the `core/media` module as requested in #61. This component provides a versatile way to display labels, categories, or status indicators with extensive customization options for colors, sizes, and styles.

---

## 🧩 Affected Module(s)

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

`feat: implement Tag component for core/media module (#61)`

---

## ✅ Checklist

- [x] My branch name follows format: `feat/tag-component`
- [x] My PR title starts with one of the approved types listed above
- [x] Code follows AGENTS.md guidelines
- [x] `pnpm format` applied
- [x] `pnpm check` passes (0 errors)
- [x] `pnpm lint` passes
- [x] For UI changes, I added Storybook stories coverage
- [x] I linked related issues using keywords like `Closes #61`
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

```text
Closes #61