### PR TITLE
chore(owner): code owner changed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,5 @@
 # Default owner
 * @husamettinarabaci
 
-
+# hexawebshare files
+/hexawebshare/ @ayseturmus @husamettinarabaci


### PR DESCRIPTION
Added code owners for hexawebshare/

---

This pull request updates the `CODEOWNERS` file to assign ownership of the `hexawebshare` directory to specific team members.