### PR TITLE
feat(utility): implement KeyboardShortcutHint component with Storybook

### DIFF
--- a/hexawebshare/src/components/utility/utility/KeyboardShortcutHint.stories.svelte
+++ b/hexawebshare/src/components/utility/utility/KeyboardShortcutHint.stories.svelte
@@ -1,0 +1,122 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import KeyboardShortcutHint from './KeyboardShortcutHint.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Utility/Utility/KeyboardShortcutHint',
+		component: KeyboardShortcutHint,
+		tags: ['autodocs'],
+		argTypes: {
+			keys: {
+				control: 'text',
+				description: 'Keyboard shortcut keys (string, array, or array of arrays)'
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'primary',
+					'secondary',
+					'accent',
+					'neutral',
+					'info',
+					'success',
+					'warning',
+					'error',
+					'ghost'
+				],
+				description: 'Color variant of the hint'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['xs', 'sm', 'md', 'lg'],
+				description: 'Size of the hint'
+			},
+			outline: {
+				control: 'boolean',
+				description: 'Outline style hint'
+			},
+			soft: {
+				control: 'boolean',
+				description: 'Soft/muted background style'
+			},
+			separator: {
+				control: 'text',
+				description: 'Separator between keys'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Disable the hint'
+			}
+		},
+		args: {
+			keys: ['Ctrl', 'K'],
+			variant: 'neutral',
+			size: 'md',
+			outline: false,
+			soft: false,
+			separator: '+',
+			disabled: false
+		}
+	});
+</script>
+
+<!-- Default Variant Story -->
+<Story name="Default" args={{ keys: ['Ctrl', 'K'], variant: 'neutral' }} />
+
+<!-- Single Key String Story -->
+<Story name="Single Key String" args={{ keys: 'Ctrl+K', variant: 'primary' }} />
+
+<!-- Multiple Keys Story -->
+<Story name="Multiple Keys" args={{ keys: ['Ctrl', 'Shift', 'P'], variant: 'accent' }} />
+
+<!-- Small Size Story -->
+<Story name="Small Size" args={{ keys: ['Cmd', 'K'], size: 'sm', variant: 'primary' }} />
+
+<!-- Large Size Story -->
+<Story name="Large Size" args={{ keys: ['Alt', 'F4'], size: 'lg', variant: 'success' }} />
+
+<!-- Outline Style Story -->
+<Story name="Outline Style" args={{ keys: ['Ctrl', 'S'], variant: 'primary', outline: true }} />
+
+<!-- Soft Style Story -->
+<Story name="Soft Style" args={{ keys: ['Esc'], variant: 'info', soft: true }} />
+
+<!-- Multiple Shortcuts Story -->
+<Story
+	name="Multiple Shortcuts"
+	args={{
+		keys: [
+			['Ctrl', 'K'],
+			['Cmd', 'K']
+		],
+		variant: 'warning'
+	}}
+/>
+
+<!-- Custom Separator Story -->
+<Story
+	name="Custom Separator"
+	args={{ keys: ['Ctrl', 'Shift', 'N'], separator: '/', variant: 'secondary' }}
+/>
+
+<!-- Disabled State Story -->
+<Story name="Disabled State" args={{ keys: ['Ctrl', 'Z'], variant: 'neutral', disabled: true }} />
+
+<!-- Playground -->
+<Story
+	name="Playground"
+	args={{
+		keys: ['Ctrl', 'K'],
+		variant: 'neutral',
+		size: 'md',
+		outline: false,
+		soft: false,
+		separator: '+',
+		disabled: false
+	}}
+/>

--- a/hexawebshare/src/components/utility/utility/KeyboardShortcutHint.svelte
+++ b/hexawebshare/src/components/utility/utility/KeyboardShortcutHint.svelte
@@ -2,3 +2,195 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	/**
+	 * Props interface for the KeyboardShortcutHint component
+	 */
+	interface Props {
+		/**
+		 * Keyboard shortcut keys to display
+		 * Can be a string (e.g., "Ctrl+K") or an array of strings (e.g., ["Ctrl", "K"])
+		 * For multiple shortcuts, use array of arrays (e.g., [["Ctrl", "K"], ["Cmd", "K"]])
+		 */
+		keys: string | string[] | string[][];
+		/**
+		 * Color variant of the hint
+		 * @default 'neutral'
+		 */
+		variant?:
+			| 'primary'
+			| 'secondary'
+			| 'accent'
+			| 'neutral'
+			| 'info'
+			| 'success'
+			| 'warning'
+			| 'error'
+			| 'ghost';
+		/**
+		 * Size of the hint
+		 * @default 'md'
+		 */
+		size?: 'xs' | 'sm' | 'md' | 'lg';
+		/**
+		 * Outline style hint
+		 * @default false
+		 */
+		outline?: boolean;
+		/**
+		 * Soft/muted background style
+		 * @default false
+		 */
+		soft?: boolean;
+		/**
+		 * Separator between keys (e.g., "+", "/", "or")
+		 * @default '+'
+		 */
+		separator?: string;
+		/**
+		 * Whether the hint is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Accessible label for screen readers
+		 * If not provided, will be auto-generated from keys
+		 */
+		ariaLabel?: string;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		keys,
+		variant = 'neutral',
+		size = 'md',
+		outline = false,
+		soft = false,
+		separator = '+',
+		disabled = false,
+		ariaLabel,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	/**
+	 * Normalize keys input to a consistent format
+	 * Converts string or array inputs to array of key groups
+	 */
+	let normalizedKeys = $derived(() => {
+		if (typeof keys === 'string') {
+			// Single string: "Ctrl+K" -> [["Ctrl", "K"]]
+			return [keys.split(/[+\/]/).map((k) => k.trim())];
+		}
+		if (Array.isArray(keys) && keys.length > 0) {
+			if (typeof keys[0] === 'string') {
+				// Array of strings: ["Ctrl", "K"] -> [["Ctrl", "K"]]
+				return [keys as string[]];
+			}
+			// Array of arrays: [["Ctrl", "K"], ["Cmd", "K"]]
+			return keys as string[][];
+		}
+		return [];
+	});
+
+	/**
+	 * Generate accessible label from keys
+	 */
+	let generatedAriaLabel = $derived(() => {
+		if (ariaLabel) return ariaLabel;
+		const keyGroups = normalizedKeys();
+		if (keyGroups.length === 0) return 'Keyboard shortcut';
+		if (keyGroups.length === 1) {
+			return `Keyboard shortcut: ${keyGroups[0].join(' + ')}`;
+		}
+		return `Keyboard shortcuts: ${keyGroups.map((group) => group.join(' + ')).join(' or ')}`;
+	});
+
+	/**
+	 * Badge classes using static DaisyUI classes
+	 */
+	let badgeClasses = $derived(
+		[
+			'badge',
+			'inline-flex',
+			'items-center',
+			'gap-1',
+			'font-mono',
+			'select-none',
+			variant === 'primary' && 'badge-primary',
+			variant === 'secondary' && 'badge-secondary',
+			variant === 'accent' && 'badge-accent',
+			variant === 'neutral' && 'badge-neutral',
+			variant === 'info' && 'badge-info',
+			variant === 'success' && 'badge-success',
+			variant === 'warning' && 'badge-warning',
+			variant === 'error' && 'badge-error',
+			variant === 'ghost' && 'badge-ghost',
+			size === 'xs' && 'badge-xs',
+			size === 'sm' && 'badge-sm',
+			size === 'md' && 'badge-md',
+			size === 'lg' && 'badge-lg',
+			outline && 'badge-outline',
+			soft && 'badge-soft',
+			disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	/**
+	 * Key badge classes for individual keys
+	 */
+	let keyBadgeClasses = $derived(
+		[
+			'badge',
+			'badge-sm',
+			'badge-ghost',
+			'px-1.5',
+			'py-0.5',
+			'min-w-[1.5rem]',
+			'justify-center',
+			'font-mono',
+			'text-xs',
+			'border',
+			'border-base-content/20'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	/**
+	 * Separator classes
+	 */
+	let separatorClasses = $derived(
+		[
+			'text-base-content/60',
+			'font-normal',
+			size === 'xs' && 'text-xs',
+			size === 'sm' && 'text-xs',
+			size === 'md' && 'text-sm',
+			size === 'lg' && 'text-base'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<span class={badgeClasses} aria-label={generatedAriaLabel()} role="status" {...props}>
+	{#each normalizedKeys() as keyGroup, groupIndex}
+		{#if groupIndex > 0}
+			<span class={separatorClasses} aria-hidden="true"> or </span>
+		{/if}
+		{#each keyGroup as key, keyIndex}
+			{#if keyIndex > 0}
+				<span class={separatorClasses} aria-hidden="true"> {separator} </span>
+			{/if}
+			<kbd class={keyBadgeClasses}>{key}</kbd>
+		{/each}
+	{/each}
+</span>


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements the `KeyboardShortcutHint` component as specified in issue #173. The component displays keyboard shortcuts in a visually appealing badge-style format with full Svelte 5 support, TypeScript interfaces, DaisyUI styling, and comprehensive Storybook stories.

**Key Features:**
- Supports multiple input formats (string, array, or array of arrays)
- Displays multiple keyboard shortcuts with "or" separator
- Customizable variants, sizes, and styles
- Full accessibility support with auto-generated ARIA labels
- Responsive design with DaisyUI static classes
- 10 variant stories plus interactive Playground

**Implementation Details:**
- Component follows Svelte 5 patterns with runes (`$props`, `$derived`)
- TypeScript interfaces for all props
- Static DaisyUI classes (no dynamic string interpolation)
- Semantic HTML with `<kbd>` tags for individual keys
- Auto-generated accessible labels for screen readers

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra


✅ PR Title:
```text
feat(utility): implement KeyboardShortcutHint component with Storybook stories
```

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/implement-keyboard-shortcut-hint)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran build successfully (pnpm build)
- [x] I ran Storybook build successfully (pnpm build-storybook)
- [x] For UI changes, I added Storybook stories with all variants
- [x] I linked related issues using keywords like Closes #173
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues


```text
Closes #173
```