### PR TITLE
feat(admin): implement RoleBadge component with Storybook stories #202

### DIFF
--- a/hexawebshare/src/components/admin/permissions/RoleBadge.stories.svelte
+++ b/hexawebshare/src/components/admin/permissions/RoleBadge.stories.svelte
@@ -1,0 +1,132 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import RoleBadge from './RoleBadge.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Admin/Permissions/RoleBadge',
+		component: RoleBadge,
+		tags: ['autodocs'],
+		argTypes: {
+			role: {
+				control: 'text',
+				description: 'Role name to display',
+				table: {
+					type: { summary: 'string' },
+					defaultValue: { summary: 'admin' }
+				}
+			},
+			variant: {
+				control: { type: 'select' },
+				options: [
+					'primary',
+					'secondary',
+					'accent',
+					'neutral',
+					'info',
+					'success',
+					'warning',
+					'error',
+					'ghost'
+				],
+				description: 'Color variant of the role badge (auto-determined if not provided)',
+				table: {
+					type: { summary: 'string' },
+					defaultValue: { summary: 'auto-determined' }
+				}
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['xs', 'sm', 'md', 'lg'],
+				description: 'Size of the role badge',
+				table: {
+					type: { summary: 'string' },
+					defaultValue: { summary: 'md' }
+				}
+			},
+			outline: {
+				control: 'boolean',
+				description: 'Outline style badge',
+				table: {
+					type: { summary: 'boolean' },
+					defaultValue: { summary: 'false' }
+				}
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Disable the role badge',
+				table: {
+					type: { summary: 'boolean' },
+					defaultValue: { summary: 'false' }
+				}
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for screen readers',
+				table: {
+					type: { summary: 'string' },
+					defaultValue: { summary: 'undefined' }
+				}
+			},
+			ariaHidden: {
+				control: 'boolean',
+				description: 'Hide badge from screen readers (decorative badges)',
+				table: {
+					type: { summary: 'boolean' },
+					defaultValue: { summary: 'false' }
+				}
+			}
+		},
+		args: {
+			role: 'admin',
+			size: 'md'
+		}
+	});
+</script>
+
+<!-- Default Story -->
+<Story name="Default" args={{ role: 'admin', size: 'md' }} />
+
+<!-- Auto-Detected Roles Showcase -->
+<Story name="Auto-Detected Roles">
+	<div class="flex flex-wrap items-center gap-4">
+		<RoleBadge role="admin" />
+		<RoleBadge role="moderator" />
+		<RoleBadge role="manager" />
+		<RoleBadge role="editor" />
+		<RoleBadge role="user" />
+		<RoleBadge role="guest" />
+	</div>
+</Story>
+
+<!-- Size Variations -->
+<Story name="Sizes">
+	<div class="flex flex-wrap items-center gap-4">
+		<RoleBadge role="admin" size="xs" />
+		<RoleBadge role="moderator" size="sm" />
+		<RoleBadge role="manager" size="md" />
+		<RoleBadge role="editor" size="lg" />
+	</div>
+</Story>
+
+<!-- Outline Style -->
+<Story name="Outline Style" args={{ role: 'admin', size: 'md', outline: true }} />
+
+<!-- Disabled State -->
+<Story name="Disabled State" args={{ role: 'admin', size: 'md', disabled: true }} />
+
+<!-- Interactive Playground (REQUIRED - must be last) -->
+<Story
+	name="Playground"
+	args={{
+		role: 'admin',
+		size: 'md',
+		outline: false,
+		disabled: false,
+		ariaLabel: 'Interactive role badge'
+	}}
+/>

--- a/hexawebshare/src/components/admin/permissions/RoleBadge.svelte
+++ b/hexawebshare/src/components/admin/permissions/RoleBadge.svelte
@@ -2,3 +2,157 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	/**
+	 * Props interface for the RoleBadge component
+	 */
+	interface Props {
+		/**
+		 * Role name to display
+		 */
+		role: string;
+		/**
+		 * Color variant of the role badge
+		 * If not provided, will be automatically determined based on role name
+		 */
+		variant?:
+			| 'primary'
+			| 'secondary'
+			| 'accent'
+			| 'neutral'
+			| 'info'
+			| 'success'
+			| 'warning'
+			| 'error'
+			| 'ghost';
+		/**
+		 * Size of the role badge
+		 * @default 'md'
+		 */
+		size?: 'xs' | 'sm' | 'md' | 'lg';
+		/**
+		 * Outline style badge
+		 * @default false
+		 */
+		outline?: boolean;
+		/**
+		 * Whether the badge is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Accessible label for screen readers
+		 */
+		ariaLabel?: string;
+		/**
+		 * Hide badge from screen readers (decorative badges)
+		 * @default false
+		 */
+		ariaHidden?: boolean;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		role,
+		variant,
+		size = 'md',
+		outline = false,
+		disabled = false,
+		ariaLabel,
+		ariaHidden = false,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	/**
+	 * Automatically determine variant based on role name if variant is not provided
+	 * Common role names are mapped to appropriate color variants
+	 */
+	let resolvedVariant = $derived.by(() => {
+		if (variant) {
+			return variant;
+		}
+
+		const roleLower = role.toLowerCase();
+
+		// Admin roles - typically use error or primary
+		if (roleLower.includes('admin') || roleLower.includes('administrator')) {
+			return 'error';
+		}
+
+		// Moderator roles - typically use warning
+		if (roleLower.includes('moderator') || roleLower.includes('mod')) {
+			return 'warning';
+		}
+
+		// Manager roles - typically use primary
+		if (roleLower.includes('manager') || roleLower.includes('mgr')) {
+			return 'primary';
+		}
+
+		// Editor roles - typically use info
+		if (roleLower.includes('editor') || roleLower.includes('edit')) {
+			return 'info';
+		}
+
+		// Guest/Visitor roles - typically use ghost
+		if (roleLower.includes('guest') || roleLower.includes('visitor')) {
+			return 'ghost';
+		}
+
+		// User/Member roles - typically use neutral
+		if (roleLower.includes('user') || roleLower.includes('member')) {
+			return 'neutral';
+		}
+
+		// Default to neutral for unknown roles
+		return 'neutral';
+	});
+
+	// Badge classes using static DaisyUI classes
+	let badgeClasses = $derived(
+		[
+			'badge',
+			resolvedVariant === 'primary' && 'badge-primary',
+			resolvedVariant === 'secondary' && 'badge-secondary',
+			resolvedVariant === 'accent' && 'badge-accent',
+			resolvedVariant === 'neutral' && 'badge-neutral',
+			resolvedVariant === 'info' && 'badge-info',
+			resolvedVariant === 'success' && 'badge-success',
+			resolvedVariant === 'warning' && 'badge-warning',
+			resolvedVariant === 'error' && 'badge-error',
+			resolvedVariant === 'ghost' && 'badge-ghost',
+			size === 'xs' && 'badge-xs',
+			size === 'sm' && 'badge-sm',
+			size === 'md' && 'badge-md',
+			size === 'lg' && 'badge-lg',
+			outline && 'badge-outline',
+			disabled && 'opacity-50 cursor-not-allowed pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Accessibility: Determine if badge is decorative or semantic
+	// Role badges are typically semantic, so default to false unless explicitly hidden
+	let isDecorative = $derived(ariaHidden || (!ariaLabel && false));
+
+	// Format role name for display (capitalize first letter)
+	let displayRole = $derived(role.charAt(0).toUpperCase() + role.slice(1).toLowerCase());
+</script>
+
+<span
+	class={badgeClasses}
+	aria-label={ariaLabel || (isDecorative ? undefined : `Role: ${displayRole}`)}
+	aria-hidden={isDecorative}
+	aria-disabled={disabled}
+	role={isDecorative ? undefined : 'status'}
+	{...props}
+>
+	{displayRole}
+</span>


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR implements the `RoleBadge` component for the admin/permissions module. The component displays role names with automatic color variant detection based on role names (admin, moderator, manager, editor, user, guest). It includes comprehensive Storybook stories demonstrating all variants, sizes, and states.

---

## 🧩 Affected Module(s)

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✅ Checklist


- [x] My branch name follows format: `feat/admin-implement-rolebadge-component`
- [x] My PR title starts with one of the approved types: `feat(admin):`
- [x] My code is formatted (`pnpm format`)
- [x] I ran static analysis (`pnpm check`) and resolved warnings
- [x] I ran build successfully (`pnpm build`)
- [x] I built Storybook successfully (`pnpm build-storybook`)
- [x] For UI changes, I added Storybook stories (5 variant stories + 1 Playground)
- [x] I linked related issues: Closes #202
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #202

---

## 💬 Additional Notes

### Component Implementation
- **Location**: `src/components/admin/permissions/RoleBadge.svelte`
- **Storybook**: `src/components/admin/permissions/RoleBadge.stories.svelte`
- **Pattern**: Svelte 5 with runes (`$props`, `$derived.by()`, `$derived`)
- **Styling**: DaisyUI static classes (no dynamic interpolation)
- **TypeScript**: Full type safety with Props interface

### Storybook Stories
1. **Default** - Basic usage
2. **Auto-Detected Roles** - Showcase of all role variants
3. **Sizes** - All size options (xs, sm, md, lg)
4. **Outline Style** - Outline variant
5. **Disabled State** - Disabled state
6. **Playground** - Interactive testing