### PR TITLE
feat(admin): add KeyValueList component and stories

### DIFF
--- a/hexawebshare/src/components/admin/crud-data/KeyValueList.stories.svelte
+++ b/hexawebshare/src/components/admin/crud-data/KeyValueList.stories.svelte
@@ -1,0 +1,266 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import KeyValueList from './KeyValueList.svelte';
+	import type { KeyValuePair } from './KeyValueList.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Admin/CRUD Data/KeyValueList',
+		component: KeyValueList,
+		tags: ['autodocs'],
+		argTypes: {
+			variant: {
+				control: { type: 'select' },
+				options: ['vertical', 'horizontal', 'table', 'compact'],
+				description: 'Layout variant of the key-value list'
+			},
+			size: {
+				control: { type: 'select' },
+				options: ['sm', 'md', 'lg'],
+				description: 'Size preset for the list items'
+			},
+			bordered: {
+				control: 'boolean',
+				description: 'Show borders around items'
+			},
+			dividers: {
+				control: 'boolean',
+				description: 'Show dividers between items'
+			},
+			keyWidth: {
+				control: { type: 'select' },
+				options: ['auto', 'narrow', 'wide'],
+				description: 'Key column width for horizontal/table layouts'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Whether the list is disabled'
+			},
+			loading: {
+				control: 'boolean',
+				description: 'Whether the list is in loading state'
+			},
+			showEmptyState: {
+				control: 'boolean',
+				description: 'Show empty state when no items'
+			},
+			emptyMessage: {
+				control: 'text',
+				description: 'Custom empty state message'
+			},
+			keyPrefix: {
+				control: 'text',
+				description: 'Prefix text for keys'
+			},
+			keySuffix: {
+				control: 'text',
+				description: 'Suffix text for keys (default: ":")'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for screen readers'
+			}
+		},
+		args: {
+			variant: 'vertical',
+			size: 'md',
+			dividers: true,
+			showEmptyState: true
+		}
+	});
+
+	// Sample data for stories
+	const sampleItems: KeyValuePair[] = [
+		{ id: 1, key: 'Name', value: 'John Doe', description: 'Full name of the user' },
+		{ id: 2, key: 'Email', value: 'john.doe@example.com' },
+		{ id: 3, key: 'Role', value: 'Administrator' },
+		{ id: 4, key: 'Status', value: 'Active' },
+		{ id: 5, key: 'Created', value: '2025-01-15', description: 'Account creation date' },
+		{ id: 6, key: 'Last Login', value: '2025-01-20 14:30' }
+	];
+
+	const mixedTypeItems: KeyValuePair[] = [
+		{ id: 1, key: 'String Value', value: 'Sample text' },
+		{ id: 2, key: 'Number Value', value: 42 },
+		{ id: 3, key: 'Boolean True', value: true },
+		{ id: 4, key: 'Boolean False', value: false },
+		{ id: 5, key: 'Null Value', value: null },
+		{ id: 6, key: 'Undefined Value', value: undefined }
+	];
+
+	const longContentItems: KeyValuePair[] = [
+		{
+			id: 1,
+			key: 'Short Key',
+			value: 'Short value text'
+		},
+		{
+			id: 2,
+			key: 'Very Long Key Name That Might Wrap',
+			value: 'This is a very long value that might wrap to multiple lines depending on the container width and layout variant being used'
+		},
+		{
+			id: 3,
+			key: 'Description Example',
+			value: 'Value with description',
+			description: 'This is additional help text that provides more context about the value'
+		}
+	];
+</script>
+
+<!-- Default Story -->
+<Story
+	name="Default"
+	args={{
+		items: sampleItems,
+		variant: 'vertical',
+		size: 'md'
+	}}
+/>
+
+<!-- Vertical Variant -->
+<Story
+	name="Vertical Variant"
+	args={{
+		items: sampleItems,
+		variant: 'vertical',
+		size: 'md',
+		dividers: true
+	}}
+/>
+
+<!-- Horizontal Variant -->
+<Story
+	name="Horizontal Variant"
+	args={{
+		items: sampleItems,
+		variant: 'horizontal',
+		size: 'md',
+		keyWidth: 'narrow'
+	}}
+/>
+
+<!-- Table Variant -->
+<Story
+	name="Table Variant"
+	args={{
+		items: sampleItems,
+		variant: 'table',
+		size: 'md'
+	}}
+/>
+
+<!-- Compact Variant -->
+<Story
+	name="Compact Variant"
+	args={{
+		items: sampleItems,
+		variant: 'compact',
+		size: 'sm'
+	}}
+/>
+
+<!-- Size Variants -->
+<Story
+	name="Small Size"
+	args={{
+		items: sampleItems,
+		variant: 'vertical',
+		size: 'sm'
+	}}
+/>
+
+<Story
+	name="Large Size"
+	args={{
+		items: sampleItems,
+		variant: 'vertical',
+		size: 'lg'
+	}}
+/>
+
+<!-- With Borders -->
+<Story
+	name="With Borders"
+	args={{
+		items: sampleItems,
+		variant: 'vertical',
+		bordered: true,
+		dividers: false
+	}}
+/>
+
+<!-- Mixed Data Types -->
+<Story
+	name="Mixed Data Types"
+	args={{
+		items: mixedTypeItems,
+		variant: 'vertical',
+		size: 'md'
+	}}
+/>
+
+<!-- Long Content -->
+<Story
+	name="Long Content"
+	args={{
+		items: longContentItems,
+		variant: 'horizontal',
+		keyWidth: 'wide'
+	}}
+/>
+
+<!-- States -->
+<Story
+	name="Disabled State"
+	args={{
+		items: sampleItems,
+		variant: 'vertical',
+		disabled: true
+	}}
+/>
+
+<Story
+	name="Loading State"
+	args={{
+		items: [],
+		variant: 'vertical',
+		loading: true
+	}}
+/>
+
+<!-- Empty State -->
+<Story
+	name="Empty State"
+	args={{
+		items: [],
+		variant: 'vertical',
+		showEmptyState: true,
+		emptyMessage: 'No data available'
+	}}
+/>
+
+<!-- Playground -->
+<Story
+	name="Playground"
+	args={{
+		items: sampleItems,
+		variant: 'vertical',
+		size: 'md',
+		bordered: false,
+		dividers: true,
+		keyWidth: 'auto',
+		disabled: false,
+		loading: false,
+		showEmptyState: true,
+		emptyMessage: 'No data available',
+		keyPrefix: '',
+		keySuffix: ':',
+		ariaLabel: 'User details'
+	}}
+/>
+

--- a/hexawebshare/src/components/admin/crud-data/KeyValueList.stories.svelte
+++ b/hexawebshare/src/components/admin/crud-data/KeyValueList.stories.svelte
@@ -101,7 +101,8 @@ SPDX-License-Identifier: MIT
 		{
 			id: 2,
 			key: 'Very Long Key Name That Might Wrap',
-			value: 'This is a very long value that might wrap to multiple lines depending on the container width and layout variant being used'
+			value:
+				'This is a very long value that might wrap to multiple lines depending on the container width and layout variant being used'
 		},
 		{
 			id: 3,
@@ -263,4 +264,3 @@ SPDX-License-Identifier: MIT
 		ariaLabel: 'User details'
 	}}
 />
-

--- a/hexawebshare/src/components/admin/crud-data/KeyValueList.svelte
+++ b/hexawebshare/src/components/admin/crud-data/KeyValueList.svelte
@@ -2,3 +2,330 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import Table, { type TableColumn } from '../../core/data-display/Table.svelte';
+	import Loader from '../../core/feedback/Loader.svelte';
+
+	/**
+	 * Key-value pair data structure
+	 */
+	export interface KeyValuePair {
+		/**
+		 * Unique identifier for the key-value pair
+		 */
+		id?: string | number;
+		/**
+		 * Key/label text
+		 */
+		key: string;
+		/**
+		 * Value text
+		 */
+		value: string | number | boolean | null | undefined;
+		/**
+		 * Optional description or help text
+		 */
+		description?: string;
+		/**
+		 * Whether this pair is disabled
+		 */
+		disabled?: boolean;
+		/**
+		 * Custom value renderer snippet
+		 */
+		valueSlot?: Snippet;
+	}
+
+	interface Props {
+		/**
+		 * Array of key-value pairs to display
+		 */
+		items?: KeyValuePair[];
+		/**
+		 * Layout variant
+		 * @default 'vertical'
+		 */
+		variant?: 'vertical' | 'horizontal' | 'table' | 'compact';
+		/**
+		 * Size preset
+		 * @default 'md'
+		 */
+		size?: 'sm' | 'md' | 'lg';
+		/**
+		 * Show borders between items
+		 * @default false
+		 */
+		bordered?: boolean;
+		/**
+		 * Show dividers between items
+		 * @default true
+		 */
+		dividers?: boolean;
+		/**
+		 * Key column width (for horizontal/table layouts)
+		 * @default 'auto'
+		 */
+		keyWidth?: string | 'auto' | 'narrow' | 'wide';
+		/**
+		 * Whether the list is disabled
+		 * @default false
+		 */
+		disabled?: boolean;
+		/**
+		 * Whether the list is in loading state
+		 * @default false
+		 */
+		loading?: boolean;
+		/**
+		 * Show empty state when no items
+		 * @default true
+		 */
+		showEmptyState?: boolean;
+		/**
+		 * Custom empty state message
+		 */
+		emptyMessage?: string;
+		/**
+		 * Key label prefix (e.g., "Field:")
+		 */
+		keyPrefix?: string;
+		/**
+		 * Key label suffix (e.g., ":")
+		 */
+		keySuffix?: string;
+		/**
+		 * Accessible label for the list
+		 */
+		ariaLabel?: string;
+		/**
+		 * ID of the element that labels this list
+		 */
+		ariaLabelledby?: string;
+		/**
+		 * Custom slot content for rendering items manually
+		 */
+		children?: Snippet;
+		/**
+		 * Additional CSS classes
+		 */
+		class?: string;
+	}
+
+	const {
+		items = [],
+		variant = 'vertical',
+		size = 'md',
+		bordered = false,
+		dividers = true,
+		keyWidth = 'auto',
+		disabled = false,
+		loading = false,
+		showEmptyState = true,
+		emptyMessage = 'No data available',
+		keyPrefix = '',
+		keySuffix = ':',
+		ariaLabel,
+		ariaLabelledby,
+		children,
+		class: className = '',
+		...props
+	}: Props = $props();
+
+	// Map admin size to core table size
+	let tableSize = $derived(size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'md');
+
+	// Table columns for the table variant using core Table component
+	type KeyValueRow = KeyValuePair;
+
+	let keyColumnWidth = $derived(
+		keyWidth === 'narrow'
+			? '8rem'
+			: keyWidth === 'wide'
+				? '12rem'
+				: typeof keyWidth === 'string' && keyWidth !== 'auto'
+					? keyWidth
+					: undefined
+	);
+
+	let tableColumns = $derived<TableColumn<KeyValueRow>[]>([
+		{
+			key: 'key',
+			label: 'Key',
+			width: keyColumnWidth,
+			render: (row) => `${keyPrefix}${row.key}${keySuffix}`
+		},
+		{
+			key: 'value',
+			label: 'Value',
+			render: (row) => {
+				const base = formatValue(row.value);
+				return row.description ? `${base} — ${row.description}` : base;
+			}
+		}
+	]);
+
+	// Generate unique ID for accessibility
+	const listId = crypto.randomUUID?.() ?? `key-value-list-${Math.random().toString(36).slice(2, 9)}`;
+
+	// Format value for display
+	function formatValue(value: string | number | boolean | null | undefined): string {
+		if (value === null || value === undefined) {
+			return '—';
+		}
+		if (typeof value === 'boolean') {
+			return value ? 'Yes' : 'No';
+		}
+		return String(value);
+	}
+
+	// Container classes for non-table variants
+	let containerClasses = $derived(
+		[
+			'key-value-list',
+			variant === 'vertical' && 'flex flex-col',
+			variant === 'horizontal' && 'flex flex-col',
+			variant === 'compact' && 'flex flex-col gap-1',
+			disabled && 'opacity-60 pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Item wrapper classes (non-table variants only)
+	let itemWrapperClasses = $derived(
+		[
+			variant === 'vertical' && 'flex flex-col',
+			variant === 'horizontal' && 'flex flex-row items-start gap-4',
+			variant === 'table' && 'table-row',
+			variant === 'compact' && 'flex flex-row items-center gap-2',
+			dividers && variant !== 'table' && variant !== 'compact' && 'border-b border-base-300 last:border-b-0',
+			bordered && variant !== 'table' && 'border border-base-300 rounded-lg p-4',
+			size === 'sm' && variant !== 'table' && 'py-2',
+			size === 'md' && variant !== 'table' && 'py-3',
+			size === 'lg' && variant !== 'table' && 'py-4'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Key cell classes
+	let keyCellClasses = $derived(
+		[
+			'key-value-list-key',
+			'font-medium',
+			'text-base-content/70',
+			variant === 'horizontal' && 'flex-shrink-0',
+			variant === 'table' && 'table-cell',
+			variant === 'table' && 'font-semibold',
+			variant === 'compact' && 'text-sm',
+			size === 'sm' && 'text-xs',
+			size === 'md' && 'text-sm',
+			size === 'lg' && 'text-base',
+			keyWidth === 'narrow' && variant === 'horizontal' && 'w-32',
+			keyWidth === 'wide' && variant === 'horizontal' && 'w-48',
+			keyWidth !== 'auto' && keyWidth !== 'narrow' && keyWidth !== 'wide' && variant === 'horizontal' && `w-[${keyWidth}]`
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Value cell classes
+	let valueCellClasses = $derived(
+		[
+			'key-value-list-value',
+			'text-base-content',
+			variant === 'horizontal' && 'flex-1',
+			variant === 'table' && 'table-cell',
+			variant === 'compact' && 'text-sm',
+			size === 'sm' && 'text-xs',
+			size === 'md' && 'text-sm',
+			size === 'lg' && 'text-base'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Description classes
+	let descriptionClasses = $derived(
+		[
+			'text-xs',
+			'text-base-content/60',
+			'mt-1',
+			variant === 'horizontal' && 'col-span-2'
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+</script>
+
+{#if variant === 'table'}
+	{#if items.length === 0 && !showEmptyState}
+		<!-- Render nothing when empty state is disabled -->
+	{:else}
+		<!-- Table variant using core Table component -->
+		<Table
+			columns={tableColumns}
+			data={items}
+			size={tableSize}
+			bordered={bordered}
+			loading={loading}
+			disabled={disabled}
+			emptyMessage={emptyMessage}
+			ariaLabel={ariaLabel}
+			class={className}
+			{...props}
+		/>
+	{/if}
+{:else}
+	<!-- Non-table variants -->
+	<div
+		id={listId}
+		class={containerClasses}
+		role="list"
+		aria-label={ariaLabel}
+		aria-labelledby={ariaLabelledby}
+		{...props}
+	>
+		{#if children}
+			{@render children()}
+		{:else if loading}
+			<!-- Loading state -->
+			<div class="flex w-full justify-center py-6">
+				<Loader
+					size={size === 'lg' ? 'lg' : size === 'sm' ? 'sm' : 'md'}
+					label="Loading data"
+					description="Fetching key-value pairs"
+					fullWidth
+				/>
+			</div>
+		{:else if items.length === 0 && showEmptyState}
+			<!-- Empty state -->
+			<div class="flex items-center justify-center py-8 text-base-content/50">
+				<span class="text-sm">{emptyMessage}</span>
+			</div>
+		{:else}
+			<!-- Vertical, Horizontal, or Compact variants -->
+			{#each items as item, index (item.id ?? index)}
+				<div class={itemWrapperClasses} class:opacity-60={item.disabled || disabled}>
+					<div class={keyCellClasses}>
+						{keyPrefix}{item.key}{keySuffix}
+					</div>
+					<div class={valueCellClasses}>
+						{#if item.valueSlot}
+							{@render item.valueSlot()}
+						{:else}
+							{formatValue(item.value)}
+						{/if}
+						{#if item.description}
+							<div class={descriptionClasses}>{item.description}</div>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		{/if}
+	</div>
+{/if}

--- a/hexawebshare/src/components/admin/crud-data/KeyValueList.svelte
+++ b/hexawebshare/src/components/admin/crud-data/KeyValueList.svelte
@@ -134,10 +134,7 @@ SPDX-License-Identifier: MIT
 	}: Props = $props();
 
 	// Map admin size to core table size
-	let tableSize = $derived(size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'md');
-
-	// Table columns for the table variant using core Table component
-	type KeyValueRow = KeyValuePair;
+	let tableSize: 'sm' | 'md' | 'lg' = $derived(size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'md');
 
 	let keyColumnWidth = $derived(
 		keyWidth === 'narrow'
@@ -149,25 +146,31 @@ SPDX-License-Identifier: MIT
 					: undefined
 	);
 
-	let tableColumns = $derived<TableColumn<KeyValueRow>[]>([
+	// Table columns for the table variant using core Table component
+	let tableColumns = $derived<TableColumn[]>([
 		{
 			key: 'key',
 			label: 'Key',
 			width: keyColumnWidth,
-			render: (row) => `${keyPrefix}${row.key}${keySuffix}`
+			render: (row) => {
+				const typedRow = row as unknown as KeyValuePair;
+				return `${keyPrefix}${typedRow.key}${keySuffix}`;
+			}
 		},
 		{
 			key: 'value',
 			label: 'Value',
 			render: (row) => {
-				const base = formatValue(row.value);
-				return row.description ? `${base} — ${row.description}` : base;
+				const typedRow = row as unknown as KeyValuePair;
+				const base = formatValue(typedRow.value);
+				return typedRow.description ? `${base} — ${typedRow.description}` : base;
 			}
 		}
 	]);
 
 	// Generate unique ID for accessibility
-	const listId = crypto.randomUUID?.() ?? `key-value-list-${Math.random().toString(36).slice(2, 9)}`;
+	const listId =
+		crypto.randomUUID?.() ?? `key-value-list-${Math.random().toString(36).slice(2, 9)}`;
 
 	// Format value for display
 	function formatValue(value: string | number | boolean | null | undefined): string {
@@ -201,7 +204,10 @@ SPDX-License-Identifier: MIT
 			variant === 'horizontal' && 'flex flex-row items-start gap-4',
 			variant === 'table' && 'table-row',
 			variant === 'compact' && 'flex flex-row items-center gap-2',
-			dividers && variant !== 'table' && variant !== 'compact' && 'border-b border-base-300 last:border-b-0',
+			dividers &&
+				variant !== 'table' &&
+				variant !== 'compact' &&
+				'border-b border-base-300 last:border-b-0',
 			bordered && variant !== 'table' && 'border border-base-300 rounded-lg p-4',
 			size === 'sm' && variant !== 'table' && 'py-2',
 			size === 'md' && variant !== 'table' && 'py-3',
@@ -226,7 +232,11 @@ SPDX-License-Identifier: MIT
 			size === 'lg' && 'text-base',
 			keyWidth === 'narrow' && variant === 'horizontal' && 'w-32',
 			keyWidth === 'wide' && variant === 'horizontal' && 'w-48',
-			keyWidth !== 'auto' && keyWidth !== 'narrow' && keyWidth !== 'wide' && variant === 'horizontal' && `w-[${keyWidth}]`
+			keyWidth !== 'auto' &&
+				keyWidth !== 'narrow' &&
+				keyWidth !== 'wide' &&
+				variant === 'horizontal' &&
+				`w-[${keyWidth}]`
 		]
 			.filter(Boolean)
 			.join(' ')
@@ -250,16 +260,10 @@ SPDX-License-Identifier: MIT
 
 	// Description classes
 	let descriptionClasses = $derived(
-		[
-			'text-xs',
-			'text-base-content/60',
-			'mt-1',
-			variant === 'horizontal' && 'col-span-2'
-		]
+		['text-xs', 'text-base-content/60', 'mt-1', variant === 'horizontal' && 'col-span-2']
 			.filter(Boolean)
 			.join(' ')
 	);
-
 </script>
 
 {#if variant === 'table'}
@@ -269,13 +273,13 @@ SPDX-License-Identifier: MIT
 		<!-- Table variant using core Table component -->
 		<Table
 			columns={tableColumns}
-			data={items}
+			data={items as unknown as Record<string, unknown>[]}
 			size={tableSize}
-			bordered={bordered}
-			loading={loading}
-			disabled={disabled}
-			emptyMessage={emptyMessage}
-			ariaLabel={ariaLabel}
+			{bordered}
+			{loading}
+			{disabled}
+			{emptyMessage}
+			{ariaLabel}
 			class={className}
 			{...props}
 		/>
@@ -304,7 +308,7 @@ SPDX-License-Identifier: MIT
 			</div>
 		{:else if items.length === 0 && showEmptyState}
 			<!-- Empty state -->
-			<div class="flex items-center justify-center py-8 text-base-content/50">
+			<div class="text-base-content/50 flex items-center justify-center py-8">
 				<span class="text-sm">{emptyMessage}</span>
 			</div>
 		{:else}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

> This PR implements the `KeyValueList` component for the admin/crud-data module as requested in issue #211. The component displays key-value pairs in multiple layout variants (vertical, horizontal, table, compact) and integrates with existing core components (`Table`, `Loader`) instead of using raw HTML. It includes comprehensive Storybook stories demonstrating all variants, sizes, states, and an interactive playground.

**Related Issue:** Closes #211

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

✅ **PR Title:**

```text
feat(admin): implement KeyValueList component (#211)
```

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (feat/admin-key-value-list)
- [x] My PR title starts with one of the approved types listed above (feat)
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (if applicable)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes
- [x] For UI changes, I added Storybook stories with all variants (11 stories including Playground)
- [x] I linked related issues using keywords like Closes #211
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues


Closes #211


