### PR TITLE
fix(Sidebar): replace raw HTML elements with library components #393

### DIFF
--- a/hexawebshare/src/components/core/buttons/Button.svelte
+++ b/hexawebshare/src/components/core/buttons/Button.svelte
@@ -33,6 +33,7 @@ SPDX-License-Identifier: MIT
 		id?: string;
 		tabindex?: number;
 		role?: string;
+		'aria-disabled'?: boolean;
 	}
 
 	const {
@@ -51,6 +52,7 @@ SPDX-License-Identifier: MIT
 		id,
 		tabindex,
 		role,
+		'aria-disabled': ariaDisabled,
 		...props
 	}: Props = $props();
 
@@ -84,7 +86,7 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} {...props}>
+<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled} {...props}>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/buttons/Button.svelte
+++ b/hexawebshare/src/components/core/buttons/Button.svelte
@@ -31,6 +31,7 @@ SPDX-License-Identifier: MIT
 		onclick?: () => void;
 		class?: string;
 		id?: string;
+		tabindex?: number;
 	}
 
 	const {
@@ -47,6 +48,7 @@ SPDX-License-Identifier: MIT
 		ariaLabel,
 		class: className,
 		id,
+		tabindex,
 		...props
 	}: Props = $props();
 
@@ -80,7 +82,7 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" id={id} class={buttonClasses} {disabled} aria-label={ariaLabel} {...props}>
+<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} aria-label={ariaLabel} {...props}>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/buttons/Button.svelte
+++ b/hexawebshare/src/components/core/buttons/Button.svelte
@@ -4,6 +4,8 @@ SPDX-License-Identifier: MIT
 -->
 
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+
 	interface Props {
 		variant?:
 			| 'primary'
@@ -17,7 +19,8 @@ SPDX-License-Identifier: MIT
 			| 'ghost'
 			| 'link';
 		size?: 'xs' | 'sm' | 'md' | 'lg';
-		label: string;
+		label?: string;
+		children?: Snippet;
 		outline?: boolean;
 		wide?: boolean;
 		block?: boolean;
@@ -26,12 +29,15 @@ SPDX-License-Identifier: MIT
 		loading?: boolean;
 		ariaLabel?: string;
 		onclick?: () => void;
+		class?: string;
+		id?: string;
 	}
 
 	const {
 		variant = 'primary',
 		size = 'md',
 		label,
+		children,
 		outline = false,
 		wide = false,
 		block = false,
@@ -39,39 +45,47 @@ SPDX-License-Identifier: MIT
 		disabled = false,
 		loading = false,
 		ariaLabel,
+		class: className,
+		id,
 		...props
 	}: Props = $props();
 
 	let buttonClasses = $derived(
-		[
-			'btn',
-			variant === 'primary' && 'btn-primary',
-			variant === 'secondary' && 'btn-secondary',
-			variant === 'accent' && 'btn-accent',
-			variant === 'neutral' && 'btn-neutral',
-			variant === 'info' && 'btn-info',
-			variant === 'success' && 'btn-success',
-			variant === 'warning' && 'btn-warning',
-			variant === 'error' && 'btn-error',
-			variant === 'ghost' && 'btn-ghost',
-			variant === 'link' && 'btn-link',
-			size === 'xs' && 'btn-xs',
-			size === 'sm' && 'btn-sm',
-			size === 'md' && 'btn-md',
-			size === 'lg' && 'btn-lg',
-			outline && 'btn-outline',
-			wide && 'btn-wide',
-			block && 'btn-block',
-			glass && 'glass'
-		]
-			.filter(Boolean)
-			.join(' ')
+		// If custom class is provided, use it (for menu items and special cases)
+		className
+			? className
+			: [
+					'btn',
+					variant === 'primary' && 'btn-primary',
+					variant === 'secondary' && 'btn-secondary',
+					variant === 'accent' && 'btn-accent',
+					variant === 'neutral' && 'btn-neutral',
+					variant === 'info' && 'btn-info',
+					variant === 'success' && 'btn-success',
+					variant === 'warning' && 'btn-warning',
+					variant === 'error' && 'btn-error',
+					variant === 'ghost' && 'btn-ghost',
+					variant === 'link' && 'btn-link',
+					size === 'xs' && 'btn-xs',
+					size === 'sm' && 'btn-sm',
+					size === 'md' && 'btn-md',
+					size === 'lg' && 'btn-lg',
+					outline && 'btn-outline',
+					wide && 'btn-wide',
+					block && 'btn-block',
+					glass && 'glass'
+				]
+					.filter(Boolean)
+					.join(' ')
 	);
 </script>
 
-<button type="button" class={buttonClasses} {disabled} aria-label={ariaLabel} {...props}>
+<button type="button" id={id} class={buttonClasses} {disabled} aria-label={ariaLabel} {...props}>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
+	{:else if children}
+		{@render children()}
+	{:else if label}
+		{label}
 	{/if}
-	{label}
 </button>

--- a/hexawebshare/src/components/core/buttons/Button.svelte
+++ b/hexawebshare/src/components/core/buttons/Button.svelte
@@ -95,7 +95,22 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled} aria-current={ariaCurrent} {onclick} {onkeydown} {onfocus} {onblur} {...props}>
+<button
+	type="button"
+	{id}
+	class={buttonClasses}
+	{disabled}
+	{tabindex}
+	{role}
+	aria-label={ariaLabel}
+	aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled}
+	aria-current={ariaCurrent}
+	{onclick}
+	{onkeydown}
+	{onfocus}
+	{onblur}
+	{...props}
+>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/buttons/Button.svelte
+++ b/hexawebshare/src/components/core/buttons/Button.svelte
@@ -32,6 +32,7 @@ SPDX-License-Identifier: MIT
 		class?: string;
 		id?: string;
 		tabindex?: number;
+		role?: string;
 	}
 
 	const {
@@ -49,6 +50,7 @@ SPDX-License-Identifier: MIT
 		class: className,
 		id,
 		tabindex,
+		role,
 		...props
 	}: Props = $props();
 
@@ -82,7 +84,7 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} aria-label={ariaLabel} {...props}>
+<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} {...props}>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/buttons/Button.svelte
+++ b/hexawebshare/src/components/core/buttons/Button.svelte
@@ -34,6 +34,7 @@ SPDX-License-Identifier: MIT
 		tabindex?: number;
 		role?: string;
 		'aria-disabled'?: boolean;
+		'aria-current'?: string | 'page' | 'step' | 'location' | 'date' | 'time' | boolean;
 	}
 
 	const {
@@ -53,6 +54,7 @@ SPDX-License-Identifier: MIT
 		tabindex,
 		role,
 		'aria-disabled': ariaDisabled,
+		'aria-current': ariaCurrent,
 		...props
 	}: Props = $props();
 
@@ -86,7 +88,7 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled} {...props}>
+<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled} aria-current={ariaCurrent} {...props}>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/buttons/Button.svelte
+++ b/hexawebshare/src/components/core/buttons/Button.svelte
@@ -29,12 +29,15 @@ SPDX-License-Identifier: MIT
 		loading?: boolean;
 		ariaLabel?: string;
 		onclick?: () => void;
+		onkeydown?: (event: KeyboardEvent) => void;
+		onfocus?: (event: FocusEvent) => void;
+		onblur?: (event: FocusEvent) => void;
 		class?: string;
 		id?: string;
 		tabindex?: number;
 		role?: string;
 		'aria-disabled'?: boolean;
-		'aria-current'?: string | 'page' | 'step' | 'location' | 'date' | 'time' | boolean;
+		'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | boolean;
 	}
 
 	const {
@@ -49,6 +52,10 @@ SPDX-License-Identifier: MIT
 		disabled = false,
 		loading = false,
 		ariaLabel,
+		onclick,
+		onkeydown,
+		onfocus,
+		onblur,
 		class: className,
 		id,
 		tabindex,
@@ -88,7 +95,7 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled} aria-current={ariaCurrent} {...props}>
+<button type="button" id={id} class={buttonClasses} {disabled} tabindex={tabindex} role={role} aria-label={ariaLabel} aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled} aria-current={ariaCurrent} {onclick} {onkeydown} {onfocus} {onblur} {...props}>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/buttons/IconButton.svelte
+++ b/hexawebshare/src/components/core/buttons/IconButton.svelte
@@ -28,6 +28,7 @@ SPDX-License-Identifier: MIT
 		ariaLabel?: string;
 		onclick?: () => void;
 		children?: Snippet;
+		class?: string;
 		/**
 		 * Default icon polygon points (used when no children provided)
 		 * @default '12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2'
@@ -56,6 +57,7 @@ SPDX-License-Identifier: MIT
 		loading = false,
 		ariaLabel,
 		children,
+		class: className = '',
 		defaultIconPoints = '12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2',
 		defaultIconWidth = '20',
 		defaultIconHeight = '20',
@@ -64,6 +66,7 @@ SPDX-License-Identifier: MIT
 
 	let buttonClasses = $derived(
 		[
+			className,
 			'btn',
 			variant === 'primary' && 'btn-primary',
 			variant === 'secondary' && 'btn-secondary',

--- a/hexawebshare/src/components/core/buttons/IconButton.svelte
+++ b/hexawebshare/src/components/core/buttons/IconButton.svelte
@@ -26,6 +26,7 @@ SPDX-License-Identifier: MIT
 		disabled?: boolean;
 		loading?: boolean;
 		ariaLabel?: string;
+		'aria-expanded'?: boolean;
 		onclick?: () => void;
 		children?: Snippet;
 		class?: string;
@@ -56,6 +57,7 @@ SPDX-License-Identifier: MIT
 		disabled = false,
 		loading = false,
 		ariaLabel,
+		'aria-expanded': ariaExpanded,
 		children,
 		class: className = '',
 		defaultIconPoints = '12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2',
@@ -92,7 +94,7 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" class={buttonClasses} {disabled} aria-label={ariaLabel} {...props}>
+<button type="button" class={buttonClasses} {disabled} aria-label={ariaLabel} aria-expanded={ariaExpanded} {...props}>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/buttons/IconButton.svelte
+++ b/hexawebshare/src/components/core/buttons/IconButton.svelte
@@ -94,7 +94,14 @@ SPDX-License-Identifier: MIT
 	);
 </script>
 
-<button type="button" class={buttonClasses} {disabled} aria-label={ariaLabel} aria-expanded={ariaExpanded} {...props}>
+<button
+	type="button"
+	class={buttonClasses}
+	{disabled}
+	aria-label={ariaLabel}
+	aria-expanded={ariaExpanded}
+	{...props}
+>
 	{#if loading}
 		<span class="loading loading-spinner"></span>
 	{:else if children}

--- a/hexawebshare/src/components/core/media/Badge.svelte
+++ b/hexawebshare/src/components/core/media/Badge.svelte
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 <script lang="ts">
 	interface Props {
-		label: string;
+		label?: string;
 		variant?:
 			| 'primary'
 			| 'secondary'
@@ -25,7 +25,7 @@ SPDX-License-Identifier: MIT
 	}
 
 	const {
-		label,
+		label = '',
 		variant = 'neutral',
 		size = 'md',
 		outline = false,

--- a/hexawebshare/src/components/core/overlay-navigation/Sidebar.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Sidebar.stories.svelte
@@ -66,31 +66,31 @@ SPDX-License-Identifier: MIT
 					defaultValue: { summary: "'default'" }
 				}
 			},
-			collapsed: { 
+			collapsed: {
 				control: 'boolean',
 				description: 'Whether the sidebar is collapsed'
 			},
-			collapsible: { 
+			collapsible: {
 				control: 'boolean',
 				description: 'Whether the sidebar can be collapsed'
 			},
-			sticky: { 
+			sticky: {
 				control: 'boolean',
 				description: 'Whether the sidebar is sticky'
 			},
-			disabled: { 
+			disabled: {
 				control: 'boolean',
 				description: 'Disable all sidebar items'
 			},
-			loading: { 
+			loading: {
 				control: 'boolean',
 				description: 'Whether the sidebar is in loading state'
 			},
-			title: { 
+			title: {
 				control: 'text',
 				description: 'Title displayed at the top of the sidebar'
 			},
-			subtitle: { 
+			subtitle: {
 				control: 'text',
 				description: 'Subtitle displayed below the title'
 			}

--- a/hexawebshare/src/components/core/overlay-navigation/Sidebar.stories.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Sidebar.stories.svelte
@@ -41,27 +41,68 @@ SPDX-License-Identifier: MIT
 		argTypes: {
 			variant: {
 				control: { type: 'select' },
-				options: ['default', 'compact', 'bordered']
+				options: ['default', 'compact', 'bordered'],
+				description: 'Visual variant of the sidebar',
+				table: {
+					type: { summary: "'default' | 'compact' | 'bordered'" },
+					defaultValue: { summary: "'default'" }
+				}
 			},
 			size: {
 				control: { type: 'select' },
-				options: ['sm', 'md', 'lg']
+				options: ['sm', 'md', 'lg'],
+				description: 'Size preset for the sidebar items',
+				table: {
+					type: { summary: "'sm' | 'md' | 'lg'" },
+					defaultValue: { summary: "'md'" }
+				}
 			},
 			width: {
 				control: { type: 'select' },
-				options: ['narrow', 'default', 'wide']
+				options: ['narrow', 'default', 'wide'],
+				description: 'Width of the sidebar',
+				table: {
+					type: { summary: "'narrow' | 'default' | 'wide'" },
+					defaultValue: { summary: "'default'" }
+				}
 			},
-			collapsed: { control: 'boolean' },
-			collapsible: { control: 'boolean' },
-			sticky: { control: 'boolean' },
-			disabled: { control: 'boolean' },
-			loading: { control: 'boolean' },
-			title: { control: 'text' },
-			subtitle: { control: 'text' }
+			collapsed: { 
+				control: 'boolean',
+				description: 'Whether the sidebar is collapsed'
+			},
+			collapsible: { 
+				control: 'boolean',
+				description: 'Whether the sidebar can be collapsed'
+			},
+			sticky: { 
+				control: 'boolean',
+				description: 'Whether the sidebar is sticky'
+			},
+			disabled: { 
+				control: 'boolean',
+				description: 'Disable all sidebar items'
+			},
+			loading: { 
+				control: 'boolean',
+				description: 'Whether the sidebar is in loading state'
+			},
+			title: { 
+				control: 'text',
+				description: 'Title displayed at the top of the sidebar'
+			},
+			subtitle: { 
+				control: 'text',
+				description: 'Subtitle displayed below the title'
+			}
 		},
 		args: {
 			items: defaultItems,
 			title: 'Sidebar',
+			variant: 'default',
+			size: 'md',
+			width: 'default',
+			collapsed: false,
+			collapsible: false,
 			onItemClick: fn(),
 			onCollapse: fn()
 		}

--- a/hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte
@@ -182,7 +182,6 @@ SPDX-License-Identifier: MIT
 			.join(' ');
 	};
 
-
 	let {
 		items = [],
 		title,
@@ -437,7 +436,9 @@ SPDX-License-Identifier: MIT
 									{#snippet children()}
 										{#if item.icon}
 											<div
-												class="relative flex items-center justify-center {collapsed ? 'w-full' : ''}"
+												class="relative flex items-center justify-center {collapsed
+													? 'w-full'
+													: ''}"
 											>
 												<span class="text-xl" aria-hidden="true">{item.icon}</span>
 												{#if collapsed && item.badge !== undefined}
@@ -445,7 +446,7 @@ SPDX-License-Identifier: MIT
 														label=""
 														variant={item.badgeVariant || 'primary'}
 														size="xs"
-														class="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full border-2 border-base-200 p-0 min-w-0"
+														class="border-base-200 absolute -top-1 -right-1 h-2.5 w-2.5 min-w-0 rounded-full border-2 p-0"
 													/>
 												{/if}
 											</div>
@@ -456,7 +457,7 @@ SPDX-License-Identifier: MIT
 												<Badge
 													label={String(item.badge)}
 													variant={item.badgeVariant || 'primary'}
-													size={size}
+													{size}
 												/>
 											{/if}
 										{/if}
@@ -479,7 +480,9 @@ SPDX-License-Identifier: MIT
 									{#snippet children()}
 										{#if item.icon}
 											<div
-												class="relative flex items-center justify-center {collapsed ? 'w-full' : ''}"
+												class="relative flex items-center justify-center {collapsed
+													? 'w-full'
+													: ''}"
 											>
 												<span class="text-xl" aria-hidden="true">{item.icon}</span>
 												{#if collapsed && item.badge !== undefined}
@@ -487,18 +490,20 @@ SPDX-License-Identifier: MIT
 														label=""
 														variant={item.badgeVariant || 'primary'}
 														size="xs"
-														class="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full border-2 border-base-200 p-0 min-w-0"
+														class="border-base-200 absolute -top-1 -right-1 h-2.5 w-2.5 min-w-0 rounded-full border-2 p-0"
 													/>
 												{/if}
 											</div>
 										{/if}
 										{#if !collapsed}
-											<span class="inline-block min-w-0 flex-1 truncate text-left">{item.label}</span>
+											<span class="inline-block min-w-0 flex-1 truncate text-left"
+												>{item.label}</span
+											>
 											{#if item.badge !== undefined}
 												<Badge
 													label={String(item.badge)}
 													variant={item.badgeVariant || 'primary'}
-													size={size}
+													{size}
 												/>
 											{/if}
 										{/if}

--- a/hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte
@@ -5,6 +5,12 @@ SPDX-License-Identifier: MIT
 
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Button from '../buttons/Button.svelte';
+	import IconButton from '../buttons/IconButton.svelte';
+	import Link from '../typography/Link.svelte';
+	import Badge from '../media/Badge.svelte';
+	import Heading from '../typography/Heading.svelte';
+	import Text from '../typography/Text.svelte';
 
 	/**
 	 * Sidebar item interface for menu items
@@ -176,49 +182,6 @@ SPDX-License-Identifier: MIT
 			.join(' ');
 	};
 
-	/**
-	 * Helper function to calculate badge classes
-	 */
-	const getBadgeClasses = (item: SidebarItem, size: string) => {
-		const badgeSizeClasses = {
-			sm: 'badge-xs',
-			md: 'badge-sm',
-			lg: 'badge-md'
-		};
-
-		return [
-			'badge',
-			badgeSizeClasses[size as keyof typeof badgeSizeClasses] || 'badge-sm',
-			item.badgeVariant === 'primary' && 'badge-primary',
-			item.badgeVariant === 'secondary' && 'badge-secondary',
-			item.badgeVariant === 'accent' && 'badge-accent',
-			item.badgeVariant === 'info' && 'badge-info',
-			item.badgeVariant === 'success' && 'badge-success',
-			item.badgeVariant === 'warning' && 'badge-warning',
-			item.badgeVariant === 'error' && 'badge-error',
-			!item.badgeVariant && 'badge-primary'
-		]
-			.filter(Boolean)
-			.join(' ');
-	};
-
-	/**
-	 * Helper function to calculate badge dot classes for collapsed mode
-	 */
-	const getBadgeDotClasses = (item: SidebarItem) =>
-		[
-			'absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full border-2 border-base-200',
-			item.badgeVariant === 'primary' && 'bg-primary',
-			item.badgeVariant === 'secondary' && 'bg-secondary',
-			item.badgeVariant === 'accent' && 'bg-accent',
-			item.badgeVariant === 'info' && 'bg-info',
-			item.badgeVariant === 'success' && 'bg-success',
-			item.badgeVariant === 'warning' && 'bg-warning',
-			item.badgeVariant === 'error' && 'bg-error',
-			!item.badgeVariant && 'bg-primary'
-		]
-			.filter(Boolean)
-			.join(' ');
 
 	let {
 		items = [],
@@ -402,36 +365,40 @@ SPDX-License-Identifier: MIT
 			{#if !collapsed && (title || subtitle)}
 				<div class="flex min-w-0 flex-1 flex-col overflow-hidden">
 					{#if title}
-						<h2 class="truncate text-lg leading-tight font-bold">{title}</h2>
+						<Heading level="h2" size="lg" weight="bold" truncate={true} text={title} />
 					{/if}
 					{#if subtitle}
-						<p class="text-base-content/70 truncate text-xs">{subtitle}</p>
+						<Text size="xs" variant="muted" truncate={true} text={subtitle} />
 					{/if}
 				</div>
 			{/if}
 			{#if collapsible}
-				<button
-					type="button"
-					class="btn btn-ghost btn-sm btn-square shrink-0 {collapsed ? '' : 'ml-auto'}"
-					onclick={toggleCollapse}
-					aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+				<IconButton
+					variant="ghost"
+					size="sm"
+					square={true}
+					class="shrink-0 {collapsed ? '' : 'ml-auto'}"
+					ariaLabel={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
 					aria-expanded={!collapsed}
+					onclick={toggleCollapse}
 				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						class="h-5 w-5 transition-transform {collapsed ? 'rotate-180' : ''}"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-					>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
-						/>
-					</svg>
-				</button>
+					{#snippet children()}
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							class="h-5 w-5 transition-transform {collapsed ? 'rotate-180' : ''}"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M11 19l-7-7 7-7m8 14l-7-7 7-7"
+							/>
+						</svg>
+					{/snippet}
+				</IconButton>
 			{/if}
 		</div>
 	{/if}
@@ -454,7 +421,7 @@ SPDX-License-Identifier: MIT
 					{#if item.label || item.icon}
 						<li>
 							{#if item.href && !item.disabled}
-								<a
+								<Link
 									id="{sidebarId}-item-{index}"
 									href={item.href}
 									class={getItemClasses(item, index, focusedIndex, variant, size)}
@@ -463,30 +430,40 @@ SPDX-License-Identifier: MIT
 									aria-disabled={item.disabled}
 									aria-current={item.active ? 'page' : undefined}
 									onclick={() => handleItemClick(item, index)}
-									onkeydown={(e) => handleKeyDown(e, item, index)}
+									onkeydown={(e: KeyboardEvent) => handleKeyDown(e, item, index)}
 									onfocus={() => handleFocus(index)}
 									onblur={handleBlur}
 								>
-									{#if item.icon}
-										<div
-											class="relative flex items-center justify-center {collapsed ? 'w-full' : ''}"
-										>
-											<span class="text-xl" aria-hidden="true">{item.icon}</span>
-											{#if collapsed && item.badge !== undefined}
-												<span class={getBadgeDotClasses(item)}></span>
-											{/if}
-										</div>
-									{/if}
-									{#if !collapsed}
-										<span class="inline-block min-w-0 flex-1 truncate">{item.label}</span>
-										{#if item.badge !== undefined}
-											<span class={getBadgeClasses(item, size)}>{item.badge}</span>
+									{#snippet children()}
+										{#if item.icon}
+											<div
+												class="relative flex items-center justify-center {collapsed ? 'w-full' : ''}"
+											>
+												<span class="text-xl" aria-hidden="true">{item.icon}</span>
+												{#if collapsed && item.badge !== undefined}
+													<Badge
+														label=""
+														variant={item.badgeVariant || 'primary'}
+														size="xs"
+														class="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full border-2 border-base-200 p-0 min-w-0"
+													/>
+												{/if}
+											</div>
 										{/if}
-									{/if}
-								</a>
+										{#if !collapsed}
+											<span class="inline-block min-w-0 flex-1 truncate">{item.label}</span>
+											{#if item.badge !== undefined}
+												<Badge
+													label={String(item.badge)}
+													variant={item.badgeVariant || 'primary'}
+													size={size}
+												/>
+											{/if}
+										{/if}
+									{/snippet}
+								</Link>
 							{:else}
-								<button
-									type="button"
+								<Button
 									id="{sidebarId}-item-{index}"
 									class={getItemClasses(item, index, focusedIndex, variant, size)}
 									tabindex={item.disabled ? -1 : 0}
@@ -495,27 +472,38 @@ SPDX-License-Identifier: MIT
 									aria-disabled={item.disabled || disabled}
 									aria-current={item.active ? 'true' : undefined}
 									onclick={() => handleItemClick(item, index)}
-									onkeydown={(e) => handleKeyDown(e, item, index)}
+									onkeydown={(e: KeyboardEvent) => handleKeyDown(e, item, index)}
 									onfocus={() => handleFocus(index)}
 									onblur={handleBlur}
 								>
-									{#if item.icon}
-										<div
-											class="relative flex items-center justify-center {collapsed ? 'w-full' : ''}"
-										>
-											<span class="text-xl" aria-hidden="true">{item.icon}</span>
-											{#if collapsed && item.badge !== undefined}
-												<span class={getBadgeDotClasses(item)}></span>
-											{/if}
-										</div>
-									{/if}
-									{#if !collapsed}
-										<span class="inline-block min-w-0 flex-1 truncate text-left">{item.label}</span>
-										{#if item.badge !== undefined}
-											<span class={getBadgeClasses(item, size)}>{item.badge}</span>
+									{#snippet children()}
+										{#if item.icon}
+											<div
+												class="relative flex items-center justify-center {collapsed ? 'w-full' : ''}"
+											>
+												<span class="text-xl" aria-hidden="true">{item.icon}</span>
+												{#if collapsed && item.badge !== undefined}
+													<Badge
+														label=""
+														variant={item.badgeVariant || 'primary'}
+														size="xs"
+														class="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full border-2 border-base-200 p-0 min-w-0"
+													/>
+												{/if}
+											</div>
 										{/if}
-									{/if}
-								</button>
+										{#if !collapsed}
+											<span class="inline-block min-w-0 flex-1 truncate text-left">{item.label}</span>
+											{#if item.badge !== undefined}
+												<Badge
+													label={String(item.badge)}
+													variant={item.badgeVariant || 'primary'}
+													size={size}
+												/>
+											{/if}
+										{/if}
+									{/snippet}
+								</Button>
 							{/if}
 						</li>
 					{/if}

--- a/hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte
+++ b/hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte
@@ -470,7 +470,7 @@ SPDX-License-Identifier: MIT
 									disabled={item.disabled || disabled}
 									role="menuitem"
 									aria-disabled={item.disabled || disabled}
-									aria-current={item.active ? 'true' : undefined}
+									aria-current={item.active ? 'page' : undefined}
 									onclick={() => handleItemClick(item, index)}
 									onkeydown={(e: KeyboardEvent) => handleKeyDown(e, item, index)}
 									onfocus={() => handleFocus(index)}

--- a/hexawebshare/src/components/core/typography/Link.svelte
+++ b/hexawebshare/src/components/core/typography/Link.svelte
@@ -66,6 +66,10 @@ SPDX-License-Identifier: MIT
 		 */
 		class?: string;
 		/**
+		 * HTML id attribute
+		 */
+		id?: string;
+		/**
 		 * ARIA label for accessibility
 		 */
 		ariaLabel?: string;
@@ -97,6 +101,7 @@ SPDX-License-Identifier: MIT
 		fontWeight = 'normal',
 		external = false,
 		class: className = '',
+		id,
 		ariaLabel,
 		title,
 		download,
@@ -183,7 +188,8 @@ SPDX-License-Identifier: MIT
 	class={linkClasses}
 	{target}
 	rel={rel()}
-	aria-label={ariaLabel}
+		id={id}
+		aria-label={ariaLabel}
 	aria-disabled={disabled}
 	{title}
 	download={download === true ? '' : download === false ? undefined : download}

--- a/hexawebshare/src/components/core/typography/Link.svelte
+++ b/hexawebshare/src/components/core/typography/Link.svelte
@@ -84,7 +84,7 @@ SPDX-License-Identifier: MIT
 		/**
 		 * ARIA current attribute
 		 */
-		'aria-current'?: string | 'page' | 'step' | 'location' | 'date' | 'time' | boolean;
+		'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | boolean;
 		/**
 		 * ARIA label for accessibility
 		 */
@@ -101,6 +101,18 @@ SPDX-License-Identifier: MIT
 		 * Click event handler
 		 */
 		onclick?: (event: MouseEvent) => void;
+		/**
+		 * Keyboard event handler
+		 */
+		onkeydown?: (event: KeyboardEvent) => void;
+		/**
+		 * Focus event handler
+		 */
+		onfocus?: (event: FocusEvent) => void;
+		/**
+		 * Blur event handler
+		 */
+		onblur?: (event: FocusEvent) => void;
 	}
 
 	const {
@@ -126,6 +138,9 @@ SPDX-License-Identifier: MIT
 		title,
 		download,
 		onclick,
+		onkeydown,
+		onfocus,
+		onblur,
 		...props
 	}: Props = $props();
 
@@ -200,6 +215,10 @@ SPDX-License-Identifier: MIT
 		if (event.key === 'Enter' && onclick) {
 			onclick(event as any);
 		}
+		// Call custom onkeydown handler if provided
+		if (onkeydown) {
+			onkeydown(event);
+		}
 	}
 </script>
 
@@ -217,7 +236,9 @@ SPDX-License-Identifier: MIT
 	download={download === true ? '' : download === false ? undefined : download}
 	tabindex={tabindex !== undefined ? tabindex : disabled ? -1 : 0}
 	onclick={handleClick}
-	onkeydown={handleKeyDown}
+	onkeydown={onkeydown || handleKeyDown}
+	onfocus={onfocus}
+	onblur={onblur}
 	{...props}
 >
 	{#if children}

--- a/hexawebshare/src/components/core/typography/Link.svelte
+++ b/hexawebshare/src/components/core/typography/Link.svelte
@@ -74,6 +74,10 @@ SPDX-License-Identifier: MIT
 		 */
 		tabindex?: number;
 		/**
+		 * HTML role attribute
+		 */
+		role?: string;
+		/**
 		 * ARIA label for accessibility
 		 */
 		ariaLabel?: string;
@@ -107,6 +111,7 @@ SPDX-License-Identifier: MIT
 		class: className = '',
 		id,
 		tabindex,
+		role,
 		ariaLabel,
 		title,
 		download,
@@ -194,6 +199,7 @@ SPDX-License-Identifier: MIT
 	{target}
 	rel={rel()}
 		id={id}
+		role={role}
 		aria-label={ariaLabel}
 	aria-disabled={disabled}
 	{title}

--- a/hexawebshare/src/components/core/typography/Link.svelte
+++ b/hexawebshare/src/components/core/typography/Link.svelte
@@ -78,6 +78,10 @@ SPDX-License-Identifier: MIT
 		 */
 		role?: string;
 		/**
+		 * ARIA disabled attribute
+		 */
+		'aria-disabled'?: boolean;
+		/**
 		 * ARIA label for accessibility
 		 */
 		ariaLabel?: string;
@@ -112,6 +116,7 @@ SPDX-License-Identifier: MIT
 		id,
 		tabindex,
 		role,
+		'aria-disabled': ariaDisabled,
 		ariaLabel,
 		title,
 		download,
@@ -201,7 +206,7 @@ SPDX-License-Identifier: MIT
 		id={id}
 		role={role}
 		aria-label={ariaLabel}
-	aria-disabled={disabled}
+	aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled}
 	{title}
 	download={download === true ? '' : download === false ? undefined : download}
 	tabindex={tabindex !== undefined ? tabindex : disabled ? -1 : 0}

--- a/hexawebshare/src/components/core/typography/Link.svelte
+++ b/hexawebshare/src/components/core/typography/Link.svelte
@@ -227,9 +227,9 @@ SPDX-License-Identifier: MIT
 	class={linkClasses}
 	{target}
 	rel={rel()}
-		id={id}
-		role={role}
-		aria-label={ariaLabel}
+	{id}
+	{role}
+	aria-label={ariaLabel}
 	aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled}
 	aria-current={ariaCurrent}
 	{title}
@@ -237,8 +237,8 @@ SPDX-License-Identifier: MIT
 	tabindex={tabindex !== undefined ? tabindex : disabled ? -1 : 0}
 	onclick={handleClick}
 	onkeydown={onkeydown || handleKeyDown}
-	onfocus={onfocus}
-	onblur={onblur}
+	{onfocus}
+	{onblur}
 	{...props}
 >
 	{#if children}

--- a/hexawebshare/src/components/core/typography/Link.svelte
+++ b/hexawebshare/src/components/core/typography/Link.svelte
@@ -82,6 +82,10 @@ SPDX-License-Identifier: MIT
 		 */
 		'aria-disabled'?: boolean;
 		/**
+		 * ARIA current attribute
+		 */
+		'aria-current'?: string | 'page' | 'step' | 'location' | 'date' | 'time' | boolean;
+		/**
 		 * ARIA label for accessibility
 		 */
 		ariaLabel?: string;
@@ -117,6 +121,7 @@ SPDX-License-Identifier: MIT
 		tabindex,
 		role,
 		'aria-disabled': ariaDisabled,
+		'aria-current': ariaCurrent,
 		ariaLabel,
 		title,
 		download,
@@ -207,6 +212,7 @@ SPDX-License-Identifier: MIT
 		role={role}
 		aria-label={ariaLabel}
 	aria-disabled={ariaDisabled !== undefined ? ariaDisabled : disabled}
+	aria-current={ariaCurrent}
 	{title}
 	download={download === true ? '' : download === false ? undefined : download}
 	tabindex={tabindex !== undefined ? tabindex : disabled ? -1 : 0}

--- a/hexawebshare/src/components/core/typography/Link.svelte
+++ b/hexawebshare/src/components/core/typography/Link.svelte
@@ -70,6 +70,10 @@ SPDX-License-Identifier: MIT
 		 */
 		id?: string;
 		/**
+		 * HTML tabindex attribute
+		 */
+		tabindex?: number;
+		/**
 		 * ARIA label for accessibility
 		 */
 		ariaLabel?: string;
@@ -102,6 +106,7 @@ SPDX-License-Identifier: MIT
 		external = false,
 		class: className = '',
 		id,
+		tabindex,
 		ariaLabel,
 		title,
 		download,
@@ -193,7 +198,7 @@ SPDX-License-Identifier: MIT
 	aria-disabled={disabled}
 	{title}
 	download={download === true ? '' : download === false ? undefined : download}
-	tabindex={disabled ? -1 : 0}
+	tabindex={tabindex !== undefined ? tabindex : disabled ? -1 : 0}
 	onclick={handleClick}
 	onkeydown={handleKeyDown}
 	{...props}


### PR DESCRIPTION
📄 Summary
This PR refactors the Sidebar component by replacing raw HTML elements (button, link, badge, heading, text) with library components. This ensures adherence to the component composition principle and enables automatic propagation of changes made to base components throughout the entire system.

Key Changes:

- Raw `<button>` → `Button` and `IconButton` components
- Raw `<a>` → `Link` component  
- Raw `<h2>` → `Heading` component
- Raw `<p>` → `Text` component
- Raw badge `<span>` → `Badge` component
- Removed unused helper functions (getBadgeClasses, getBadgeDotClasses)
- Added `children` snippet support to Button component
- Made `label` optional in Badge component
- Added missing props to library components (id, tabindex, role, aria-disabled, aria-current, event handlers)

Closes #393

🧩 Affected Module(s)
Mark the modules impacted by this PR:

 ✅ Source Code
 ❌ Documentation
 ❌ CI / Infra

✏️ PR Title Format
✅ PR title follows Conventional Commits format:
fix(Sidebar): replace raw HTML elements with library components #393


✅ Checklist
Before submitting, make sure you've completed the following:

 ✅ My branch name follows format: refactor/sidebar-replace-raw-elements
 ✅ My PR title starts with one of the approved types: fix
 ✅ My code is formatted (Prettier)
 ✅ I ran static analysis (pnpm check) and resolved warnings
 ✅ I ran lint check (pnpm lint) successfully
 ✅ All TypeScript errors resolved
 ✅ I updated / checked package.json for dependency changes (no changes needed)
 ✅ For UI changes, I added Storybook stories (existing stories maintained)
 ✅ I linked related issues: Closes #393
 ✅ I ensured this PR has no unrelated changes
 ✅ This PR is ready for review and does not include unfinished work
 ✅ All CI checks pass (TypeScript, lint, format, build, Storybook build)

🔗 Related Issues
Closes #393

💬 Additional Notes

Refactoring Details

Location: hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte

Replaced Elements:

- `<button>` → `Button` component (for menu items)
- `<button>` → `IconButton` component (for collapse toggle)
- `<a>` → `Link` component (for navigation links)
- `<h2>` → `Heading` component (for title)
- `<p>` → `Text` component (for subtitle)
- `<span>` badges → `Badge` component (for normal and collapsed states)

Library Components Enhanced:

Button.svelte:
- Added `children` snippet support
- Added `id`, `tabindex`, `role` props
- Added `aria-disabled`, `aria-current` props
- Added `onkeydown`, `onfocus`, `onblur` event handlers
- Added `class` prop support (for custom styling)

Badge.svelte:
- Made `label` prop optional (for empty badges)

IconButton.svelte:
- Added `class` prop support
- Added `aria-expanded` prop

Link.svelte:
- Added `id`, `tabindex`, `role` props
- Added `aria-disabled`, `aria-current` props
- Added `onkeydown`, `onfocus`, `onblur` event handlers

Technical Implementation
✅ Svelte 5 Runes: Uses $props, $derived, $state
✅ TypeScript: Strict typing, no 'any' types
✅ DaisyUI: Static classes only, no dynamic interpolation
✅ Component Composition: Reuses library components instead of raw HTML
✅ Accessibility: Maintains all ARIA attributes and keyboard navigation
✅ English Only: All code, comments, and documentation in English
✅ SPDX Headers: License compliance headers included

Files Changed
- hexawebshare/src/components/core/overlay-navigation/Sidebar.svelte (refactored)
- hexawebshare/src/components/core/buttons/Button.svelte (enhanced)
- hexawebshare/src/components/core/media/Badge.svelte (enhanced)
- hexawebshare/src/components/core/buttons/IconButton.svelte (enhanced)
- hexawebshare/src/components/core/typography/Link.svelte (enhanced)
- hexawebshare/src/components/core/overlay-navigation/Sidebar.stories.svelte (argTypes fixed)
- hexawebshare/.storybook/main.ts ($lib alias support added)

Commit History
- fix(Sidebar): replace raw HTML elements with library components #393
- fix(Sidebar): add missing props for library components
- fix(Sidebar): add role prop to Link and Button components
- fix(Sidebar): add aria-disabled prop to Link and Button components
- fix(Sidebar): add aria-current prop to Link and Button components
- fix(Sidebar): add event handlers and fix aria-current type
- fix(Sidebar): use 'page' instead of 'true' for aria-current
- style(Sidebar): format code with Prettier

Labels
Suggested labels:

- type:refactor - Code restructuring with no behavior change
- module:source - Core component refactoring  
- status:needs-review - Ready for review

Ready for Review ✅