### PR TITLE
fix(FileUpload): replace raw buttons with library Button/IconButton components

### DIFF
--- a/hexawebshare/src/components/core/forms/FileUpload.svelte
+++ b/hexawebshare/src/components/core/forms/FileUpload.svelte
@@ -4,6 +4,9 @@ SPDX-License-Identifier: MIT
 -->
 
 <script lang="ts">
+	import Button from '../buttons/Button.svelte';
+	import IconButton from '../buttons/IconButton.svelte';
+
 	/**
 	 * Props interface for the FileUpload component
 	 */
@@ -182,29 +185,6 @@ SPDX-License-Identifier: MIT
 			size === 'sm' && 'p-4',
 			size === 'md' && 'p-6',
 			size === 'lg' && 'p-8'
-		]
-			.filter(Boolean)
-			.join(' ')
-	);
-
-	// Button classes
-	let buttonClasses = $derived(
-		[
-			'btn',
-			'btn-sm',
-			variant === 'primary' && 'btn-primary',
-			variant === 'secondary' && 'btn-secondary',
-			variant === 'accent' && 'btn-accent',
-			variant === 'info' && 'btn-info',
-			variant === 'success' && 'btn-success',
-			variant === 'warning' && 'btn-warning',
-			variant === 'error' && 'btn-error',
-			!variant && 'btn-outline',
-			disabled && 'btn-disabled',
-			size === 'xs' && 'btn-xs',
-			size === 'sm' && 'btn-sm',
-			size === 'md' && 'btn-md',
-			size === 'lg' && 'btn-lg'
 		]
 			.filter(Boolean)
 			.join(' ')
@@ -442,16 +422,22 @@ SPDX-License-Identifier: MIT
 					{#if dragDrop}
 						Drag and drop files here, or
 					{/if}
-					<button
-						type="button"
-						class={buttonClasses}
+					<span
 						onclick={(e) => {
 							e.stopPropagation();
-							triggerFileInput();
 						}}
 					>
-						browse
-					</button>
+						<Button
+							label="browse"
+							variant={variant || undefined}
+							{size}
+							outline={!variant}
+							{disabled}
+							onclick={() => {
+								triggerFileInput();
+							}}
+						/>
+					</span>
 				</div>
 				{#if helpText && (!error || error === '')}
 					<p class="text-base-content/70 text-xs">{helpText}</p>
@@ -473,9 +459,7 @@ SPDX-License-Identifier: MIT
 					{selectedFiles.length} file{selectedFiles.length > 1 ? 's' : ''} selected
 				</span>
 				{#if multiple && selectedFiles.length > 1}
-					<button type="button" class="btn btn-ghost btn-xs" onclick={clearAll} {disabled}>
-						Clear all
-					</button>
+					<Button label="Clear all" variant="ghost" size="xs" {disabled} onclick={clearAll} />
 				{/if}
 			</div>
 			<div class="space-y-2">
@@ -487,29 +471,31 @@ SPDX-License-Identifier: MIT
 							<p class="text-base-content truncate text-sm font-medium">{file.name}</p>
 							<p class="text-base-content/70 text-xs">{formatFileSize(file.size)}</p>
 						</div>
-						<button
-							type="button"
-							class="btn btn-ghost btn-xs ml-2"
-							onclick={() => removeFile(index)}
-							{disabled}
-							aria-label="Remove file"
-						>
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								class="h-4 w-4"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-								aria-hidden="true"
+						<span class="ml-2">
+							<IconButton
+								variant="ghost"
+								size="xs"
+								ariaLabel="Remove file"
+								{disabled}
+								onclick={() => removeFile(index)}
 							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M6 18L18 6M6 6l12 12"
-								/>
-							</svg>
-						</button>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									class="h-4 w-4"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+									aria-hidden="true"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+							</IconButton>
+						</span>
 					</div>
 				{/each}
 			</div>


### PR DESCRIPTION
📄 Summary
This PR refactors the FileUpload component to follow the Component Composition & Reusability Principle by replacing raw HTML `<button>` elements with library Button and IconButton components. This ensures that future enhancements to Button/IconButton components automatically propagate to FileUpload, maintaining consistency across the codebase.

Key Changes:

- Replaced 3× raw `<button>` elements with library components
- Browse button now uses `<Button>` component with proper variant/size props
- "Clear all" button uses `<Button variant="ghost" size="xs">`
- File removal buttons use `<IconButton variant="ghost" size="xs">` with close icon
- Removed manual `buttonClasses` computation (no longer needed)
- Imported Button and IconButton from core/buttons using relative paths
- Maintained all existing functionality and behavior
- Improved accessibility through library component features

Closes #394

🧩 Affected Module(s)
Mark the modules impacted by this PR:

✅ Source Code
 Documentation
 CI / Infra

✏️ PR Title Format
✅ PR title follows Conventional Commits format:
fix(FileUpload): replace raw buttons with library Button/IconButton components

✅ Checklist
Before submitting, make sure you've completed the following:

✅ My branch name follows format: fix/fileupload-replace-raw-buttons
✅ My PR title starts with one of the approved types: fix
✅ My code is formatted (Prettier)
✅ I ran static analysis (pnpm check) and resolved warnings
✅ I ran lint check (pnpm lint) successfully
✅ All TypeScript errors resolved
✅ I updated / checked package.json for dependency changes (no changes needed)
✅ For UI changes, I verified Storybook stories (existing stories work correctly)
✅ I linked related issues: Closes #394
✅ I ensured this PR has no unrelated changes
✅ This PR is ready for review and does not include unfinished work
✅ All CI checks pass (TypeScript, lint, format, build, Storybook build)

🔗 Related Issues
Closes #394

💬 Additional Notes

Component Details
Location: hexawebshare/src/components/core/forms/FileUpload.svelte

Changes Made:

1. Browse Button (lines 429-438):
   - Replaced raw `<button>` with `<Button>` component
   - Uses variant, size, outline, disabled props
   - Wrapped in span for stopPropagation handling

2. Clear All Button (line 461):
   - Replaced raw `<button>` with `<Button variant="ghost" size="xs">`
   - Maintains same functionality and appearance

3. File Removal Buttons (lines 474-496):
   - Replaced raw `<button>` with `<IconButton variant="ghost" size="xs">`
   - Close icon SVG passed as children
   - Maintains aria-label="Remove file"

4. Code Cleanup:
   - Removed `buttonClasses` derived computation (lines 193-214)
   - Removed unused manual class management

Core Components Used:

- Button - Browse and "Clear all" buttons
- IconButton - File removal buttons with close icon

Import Strategy:
- Using relative paths: `../buttons/Button.svelte` and `../buttons/IconButton.svelte`
- Consistent with other components in the codebase

Technical Implementation
✅ Svelte 5 Runes: Uses $props, $derived, $state
✅ TypeScript: Strict typing, no 'any' types
✅ DaisyUI: Static classes only, no dynamic interpolation
✅ Component Composition: Reuses library Button/IconButton components instead of raw HTML
✅ Accessibility: Inherits accessibility features from Button/IconButton components
✅ English Only: All code, comments, and documentation in English
✅ SPDX Headers: License compliance headers included
✅ No Raw HTML Buttons: All interactive buttons use library components

Testing Instructions
Storybook: Run `pnpm storybook` in hexawebshare directory
Navigate to: Core/Forms/FileUpload
Test all stories:
- Verify "browse" button works correctly (opens file dialog)
- Test "Clear all" button (appears when multiple files selected, clears all files)
- Test file removal buttons (X icon appears for each file, removes individual files)
- Verify all buttons maintain proper styling (ghost variant, xs size)
- Test disabled state (all buttons respect disabled prop)
- Verify visual consistency with other components using Button/IconButton

Files Changed
hexawebshare/src/components/core/forms/FileUpload.svelte (modified)

Commit History
fix(FileUpload): replace raw buttons with library Button/IconButton components

Labels
Suggested labels:

type:refactor - Code restructuring with no behavior change
module:core - Core components module
status:needs-review - Ready for review

Ready for Review ✅