### PR TITLE
fix(Alert): replace raw elements with library components

### DIFF
--- a/hexawebshare/src/components/core/buttons/IconButton.svelte
+++ b/hexawebshare/src/components/core/buttons/IconButton.svelte
@@ -18,6 +18,7 @@ SPDX-License-Identifier: MIT
 			| 'error'
 			| 'ghost'
 			| 'link';
+		title?: string;
 		size?: 'xs' | 'sm' | 'md' | 'lg';
 		circle?: boolean;
 		square?: boolean;

--- a/hexawebshare/src/components/core/feedback/Alert.svelte
+++ b/hexawebshare/src/components/core/feedback/Alert.svelte
@@ -6,6 +6,10 @@ SPDX-License-Identifier: MIT
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import Spinner from './Spinner.svelte';
+	import Button from '../buttons/Button.svelte';
+	import IconButton from '../buttons/IconButton.svelte';
+	import Heading from '../typography/Heading.svelte';
+	import MutedText from '../typography/MutedText.svelte';
 
 	type SlotContent = Snippet | { default?: Snippet };
 	type AlertVariant =
@@ -253,15 +257,15 @@ SPDX-License-Identifier: MIT
 
 		<div class="flex min-w-0 flex-1 flex-col gap-1">
 			{#if title}
-				<div id={titleId} class="text-base leading-tight font-semibold">
+				<Heading level="h4" text={title} class="text-base leading-tight font-semibold" id={titleId}>
 					{title}
-				</div>
+				</Heading>
 			{/if}
 
 			{#if description}
-				<p id={descriptionId} class="text-sm leading-snug break-words opacity-80">
+				<MutedText size="sm" class="leading-snug break-words opacity-80" id={descriptionId}>
 					{description}
-				</p>
+				</MutedText>
 			{/if}
 
 			{#if defaultSlot}
@@ -284,28 +288,29 @@ SPDX-License-Identifier: MIT
 		{/if}
 
 		{#if actionLabel}
-			<button
-				type="button"
-				class="btn btn-outline btn-sm"
+			<Button
+				variant="ghost"
+				size="sm"
+				class="btn-outline"
 				onclick={handleAction}
-				aria-label={actionAriaLabel ?? actionLabel}
+				ariaLabel={actionAriaLabel ?? actionLabel}
 				disabled={disabled || loading}
-			>
-				{actionLabel}
-			</button>
+				label={actionLabel}
+			/>
 		{/if}
 
 		{#if closable}
-			<button
-				type="button"
-				class="btn btn-square btn-ghost btn-sm"
+			<IconButton
+				variant="ghost"
+				size="sm"
+				square
 				onclick={handleClose}
-				aria-label={dismissLabel}
+				ariaLabel={dismissLabel}
 				title={dismissLabel}
 				disabled={disabled || loading}
 			>
 				<span aria-hidden="true">x</span>
-			</button>
+			</IconButton>
 		{/if}
 	</div>
 {/if}

--- a/hexawebshare/src/components/core/typography/Heading.svelte
+++ b/hexawebshare/src/components/core/typography/Heading.svelte
@@ -19,6 +19,10 @@ SPDX-License-Identifier: MIT
 		 */
 		text?: string;
 		/**
+		 * Element ID
+		 */
+		id?: string;
+		/**
 		 * HTML heading level (h1, h2, h3, h4, h5, h6)
 		 * @default 'h2'
 		 */

--- a/hexawebshare/src/components/core/typography/MutedText.svelte
+++ b/hexawebshare/src/components/core/typography/MutedText.svelte
@@ -98,6 +98,10 @@ opacity-50 cursor-not-allowed
 		 */
 		strikethrough?: boolean;
 		/**
+		 * Element ID
+		 */
+		id?: string;
+		/**
 		 * Accessible label for screen readers
 		 */
 		ariaLabel?: string;


### PR DESCRIPTION
## 📄 Summary

Refactors the `Alert` component to use library components (`Heading`, `MutedText`, `Button`, `IconButton`) instead of raw HTML elements (`div`, `p`, `button`). This ensures adherence to the Component Composition & Reusability Principle and improves consistency across the application.

Technically, this required updating `Heading`, `MutedText`, and `IconButton` components to accept `id` and `title` props to support accessibility attributes (`aria-labelledby`, `aria-describedby`) used within the Alert component.

> Linked to issue: #398

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)  *(Note: Applied `pnpm format` for Svelte)*
- [x] I ran static analysis (flutter analyze) and resolved warnings *(Note: Ran `pnpm check` & `pnpm lint`)*
- [x] I ran tests successfully (flutter test) *(Note: Verified via Storybook & Build)*
- [ ] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [ ] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I linked related issues using keywords like Closes #42
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

> **Note:** The template references Flutter/Dart commands, but equivalent Svelte/TypeScript checks (`pnpm check`, `pnpm lint`, `pnpm build`) have been performed successfully.

---

## 🔗 Related Issues

```text
Closes #398