### PR TITLE
fix(Notification): replace raw buttons and text with library components

### DIFF
--- a/hexawebshare/src/components/core/feedback/Notification.svelte
+++ b/hexawebshare/src/components/core/feedback/Notification.svelte
@@ -5,6 +5,11 @@ SPDX-License-Identifier: MIT
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import Spinner from './Spinner.svelte';
+	import Button from '../buttons/Button.svelte';
+	import IconButton from '../buttons/IconButton.svelte';
+	import Heading from '../typography/Heading.svelte';
+	import MutedText from '../typography/MutedText.svelte';
+	import StatusDot from '../data-display/StatusDot.svelte';
 
 	type Children = Snippet | { default?: Snippet };
 
@@ -160,26 +165,6 @@ SPDX-License-Identifier: MIT
 			.join(' ')
 	);
 
-	let indicatorClasses = $derived(
-		[
-			'h-2',
-			'w-2',
-			'rounded-full',
-			'mt-1.5',
-			'sm:mt-0',
-			variant === 'primary' && 'bg-primary',
-			variant === 'secondary' && 'bg-secondary',
-			variant === 'accent' && 'bg-accent',
-			variant === 'neutral' && 'bg-neutral',
-			variant === 'info' && 'bg-info',
-			variant === 'success' && 'bg-success',
-			variant === 'warning' && 'bg-warning',
-			variant === 'error' && 'bg-error'
-		]
-			.filter(Boolean)
-			.join(' ')
-	);
-
 	const handleClose = () => {
 		if (!isControlled) {
 			isVisible = false;
@@ -201,16 +186,16 @@ SPDX-License-Identifier: MIT
 		{...props}
 	>
 		{#if withIcon}
-			<span class={indicatorClasses} aria-hidden="true"></span>
+			<StatusDot {variant} size="sm" ariaHidden class="mt-1.5 sm:mt-0" />
 		{/if}
 
 		<div class="flex min-w-0 flex-1 flex-col gap-1">
 			{#if title}
-				<div class="text-base leading-tight font-semibold">{title}</div>
+				<Heading level="h6" text={title} weight="semibold" class="leading-tight" />
 			{/if}
 
 			{#if message}
-				<p class="text-sm leading-snug break-words opacity-80">{message}</p>
+				<MutedText text={message} size="sm" class="leading-snug break-words" />
 			{/if}
 
 			{@render defaultSlot?.()}
@@ -226,28 +211,27 @@ SPDX-License-Identifier: MIT
 		{/if}
 
 		{#if actionLabel}
-			<button
-				type="button"
-				class="btn btn-outline btn-sm"
+			<Button
+				variant="ghost"
+				size="sm"
+				label={actionLabel}
 				onclick={handleAction}
-				aria-label={actionAriaLabel ?? actionLabel}
+				ariaLabel={actionAriaLabel ?? actionLabel}
 				disabled={disabled || loading}
-			>
-				{actionLabel}
-			</button>
+			/>
 		{/if}
 
 		{#if closable}
-			<button
-				type="button"
-				class="btn btn-square btn-ghost btn-sm"
+			<IconButton
+				variant="ghost"
+				size="sm"
+				square
 				onclick={handleClose}
-				aria-label={dismissLabel}
-				title={dismissLabel}
+				ariaLabel={dismissLabel}
 				disabled={disabled || loading}
 			>
-				<span aria-hidden="true">×</span>
-			</button>
+				×
+			</IconButton>
 		{/if}
 	</div>
 {/if}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

Refactors [Notification.svelte](cci:7://file:///home/celik/Documents/projects/hexaWebShare/hexawebshare/src/components/core/feedback/Notification.svelte:0:0-0:0) to follow the Component Composition & Reusability Principle by replacing raw HTML elements with library components.

**Changes made:**
| Before | After |
|--------|-------|
| Raw `<button>` for action | `<Button variant="ghost" size="sm">` |
| Raw `<button>` for close | `<IconButton variant="ghost" size="sm" square>` |
| Raw `<div>` for title | `<Heading level="h6" weight="semibold">` |
| Raw `<p>` for message | `<MutedText size="sm">` |
| Raw `<span>` for indicator | `<StatusDot variant={variant} size="sm">` |

---

## 🧩 Affected Module(s)

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✅ Checklist

- [x] My branch name follows format: `fix/notification-refactor-components`
- [x] My PR title starts with one of the approved types listed above
- [x] Code is formatted (`pnpm format`)
- [x] I ran static analysis (`pnpm check`) and resolved warnings
- [x] Build succeeds (`pnpm build`)
- [ ] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I linked related issues using keywords like `Closes #401`
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #401

---

## 💬 Additional Notes (Optional)

Component enhancements now automatically propagate to Notification, ensuring consistent button and typography behavior across the library with better accessibility inheritance.