### PR TITLE
refactor(CardSection): replace raw headings and text with library components

### DIFF
--- a/hexawebshare/src/components/core/layout/CardSection.svelte
+++ b/hexawebshare/src/components/core/layout/CardSection.svelte
@@ -5,6 +5,9 @@ SPDX-License-Identifier: MIT
 
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Heading from '../typography/Heading.svelte';
+	import Text from '../typography/Text.svelte';
+	import Spinner from '../feedback/Spinner.svelte';
 
 	/**
 	 * Props interface for the CardSection component
@@ -189,14 +192,14 @@ SPDX-License-Identifier: MIT
 
 					<div class="flex-1">
 						{#if title}
-							<span class="card-section-title text-base-content block text-base font-semibold">
+							<Heading level="h3" weight="semibold" size="md" class="card-section-title">
 								{title}
-							</span>
+							</Heading>
 						{/if}
 						{#if description}
-							<span class="card-section-description text-base-content/70 mt-1 block text-sm">
+							<Text variant="muted" size="sm" display="block" class="card-section-description mt-1">
 								{description}
-							</span>
+							</Text>
 						{/if}
 					</div>
 				</div>
@@ -229,14 +232,14 @@ SPDX-License-Identifier: MIT
 
 					<div class="flex-1">
 						{#if title}
-							<h3 class="card-section-title text-base-content text-base font-semibold">
+							<Heading level="h3" weight="semibold" size="md" class="card-section-title">
 								{title}
-							</h3>
+							</Heading>
 						{/if}
 						{#if description}
-							<p class="card-section-description text-base-content/70 mt-1 text-sm">
+							<Text variant="muted" size="sm" display="block" class="card-section-description mt-1">
 								{description}
-							</p>
+							</Text>
 						{/if}
 					</div>
 				</div>
@@ -255,7 +258,7 @@ SPDX-License-Identifier: MIT
 	<div class={contentClasses}>
 		{#if loading}
 			<div class="flex items-center justify-center py-8" aria-label="Loading content">
-				<span class="loading loading-spinner loading-md"></span>
+				<Spinner size="md" variant="neutral" ariaLabel="Loading section content" />
 			</div>
 		{:else if children}
 			{@render children()}


### PR DESCRIPTION
## Description
This PR refactors the [CardSection.svelte](cci:7://file:///home/celik/Documents/projects/hexaWebShare/hexawebshare/src/components/core/layout/CardSection.svelte:0:0-0:0) component to adhere to the project's **Component Composition & Reusability Principle**. Raw HTML text and loading elements have been replaced with existing library components to ensure consistent styling and centralized maintenance.

## Changes
- Imported `Heading`, `Text`, and `Spinner` components.
- Replaced raw `<span>` and `<h3>` titles with `<Heading level="h3" weight="semibold" size="md">`.
- Replaced raw `<span>` and `<p>` descriptions with `<Text variant="muted" size="sm" display="block">`.
- Replaced raw DaisyUI loading span with the library's `<Spinner>` component.
- Used relative imports to maintain compatibility within the `core/layout` directory.

## Impact
- Typography enhancements will now automatically propagate to `CardSection`.
- Consistent heading and text styling across all card instances.
- Better alignment with the library's design system.

## Checklist
- [x] Title follows conventional format
- [x] Title and description are in English only
- [x] All checks pass (`pnpm check`, `pnpm format`, `pnpm lint`, `pnpm build`)
- [x] Code is formatted with Prettier
- [x] No non-English text anywhere
- [x] Branch name follows strategy (`refactor/cardsection-library-components`)
- [x] Commits follow strategy

Fixes #402