### PR TITLE
refactor(Toast): replace raw HTML with library components

### DIFF
--- a/hexawebshare/src/components/core/feedback/Toast.svelte
+++ b/hexawebshare/src/components/core/feedback/Toast.svelte
@@ -5,6 +5,10 @@ SPDX-License-Identifier: MIT
 
 <script lang="ts">
 	import { onDestroy } from 'svelte';
+	import Button from '../buttons/Button.svelte';
+	import IconButton from '../buttons/IconButton.svelte';
+	import Text from '../typography/Text.svelte';
+	import Spinner from './Spinner.svelte';
 
 	type ToastVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';
 	type ToastPosition =
@@ -243,32 +247,30 @@ SPDX-License-Identifier: MIT
 				{/if}
 
 				{#if loading}
-					<span class="loading loading-spinner loading-sm text-current" aria-hidden="true"></span>
+					<Spinner type="spinner" size="sm" class="text-current" ariaLabel="Loading" />
 				{/if}
 
 				<div class="flex-1 space-y-1">
 					{#if title}
-						<p class="leading-tight font-semibold">{title}</p>
+						<Text display="block" weight="semibold" leading="tight" text={title} />
 					{/if}
-					<p class="text-sm leading-snug">{message}</p>
+					<Text display="block" size="sm" leading="snug" text={message} />
 				</div>
 
 				{#if actionLabel}
-					<button type="button" class="btn btn-ghost btn-sm" onclick={handleAction} {disabled}>
-						{actionLabel}
-					</button>
+					<Button variant="ghost" size="sm" label={actionLabel} onclick={handleAction} {disabled} />
 				{/if}
 
 				{#if closable}
-					<button
-						type="button"
-						class="btn btn-square btn-ghost btn-sm"
-						aria-label="Close notification"
+					<IconButton
+						variant="ghost"
+						size="sm"
+						square
+						ariaLabel="Close notification"
 						onclick={handleDismiss}
 						{disabled}
-					>
-						<span aria-hidden="true">&times;</span>
-					</button>
+						defaultIconPoints="18 6 6 18 M 6 6 18 18"
+					/>
 				{/if}
 			</div>
 		</div>


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR refactors the `Toast` component to use library components instead of raw HTML elements, following the project's compositional architecture guidelines. This ensures that features added to base components (Button, IconButton, Text, Spinner) automatically propagate to the Toast component, improving maintainability and consistency across the component library.

**Changes:**
- Replaced raw action button (`<button class="btn btn-ghost btn-sm">`) with `Button` component
- Replaced raw close button (`<button class="btn btn-square btn-ghost btn-sm">`) with `IconButton` component
- Replaced raw title and message `<p>` tags with `Text` component
- Replaced raw loading spinner (`<span class="loading loading-spinner...">`) with `Spinner` component

This refactoring addresses issue #404 and aligns with the project's component composition principle.

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format

**PR Title:** `refactor(Toast): replace raw HTML with library components`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., refactor/toast-use-library-components)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (if applicable)
- [x] I updated / checked package.json and pnpm-lock.yaml for dependency changes
- [ ] For UI changes, I added screenshots and/or updated Storybook stories (if applicable)
- [x] I linked related issues using keywords like Closes #404
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #404
