### PR TITLE
fix(EmptyState): replace raw headings and text with library components

### DIFF
--- a/hexawebshare/src/components/core/data-display/EmptyState.svelte
+++ b/hexawebshare/src/components/core/data-display/EmptyState.svelte
@@ -5,6 +5,8 @@ SPDX-License-Identifier: MIT
 
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Heading from '../typography/Heading.svelte';
+	import Text from '../typography/Text.svelte';
 
 	/**
 	 * Props interface for the EmptyState component
@@ -255,7 +257,7 @@ SPDX-License-Identifier: MIT
 		<div class="flex flex-col items-center justify-center gap-4">
 			<span class="loading loading-spinner {spinnerSizeClass} text-primary" aria-hidden="true"
 			></span>
-			<p class="text-base-content/70 text-sm">Loading...</p>
+			<Text size="sm" variant="muted" text="Loading..." />
 		</div>
 	{:else}
 		<!-- Icon -->
@@ -285,16 +287,12 @@ SPDX-License-Identifier: MIT
 
 		<!-- Title -->
 		{#if title}
-			<h3 id={titleId} class={titleClasses}>
-				{title}
-			</h3>
+			<Heading level="h3" text={title} id={titleId} class={titleClasses} />
 		{/if}
 
 		<!-- Description -->
 		{#if description}
-			<p id={descriptionId} class={descriptionClasses}>
-				{description}
-			</p>
+			<Text display="block" text={description} id={descriptionId} class={descriptionClasses} />
 		{/if}
 
 		<!-- Custom content slot -->

--- a/hexawebshare/src/components/core/typography/Heading.svelte
+++ b/hexawebshare/src/components/core/typography/Heading.svelte
@@ -110,6 +110,10 @@ SPDX-License-Identifier: MIT
 		 */
 		ariaLevel?: number;
 		/**
+		 * HTML id attribute
+		 */
+		id?: string;
+		/**
 		 * Additional CSS classes
 		 */
 		class?: string;
@@ -139,6 +143,7 @@ SPDX-License-Identifier: MIT
 		withMargin = false,
 		ariaLabel,
 		ariaLevel,
+		id,
 		class: className = '',
 		onclick,
 		...props
@@ -348,6 +353,7 @@ SPDX-License-Identifier: MIT
 
 {#if level === 'h1'}
 	<h1
+		{id}
 		class={headingClasses}
 		aria-label={ariaLabel}
 		aria-level={ariaLevel}
@@ -362,6 +368,7 @@ SPDX-License-Identifier: MIT
 	</h1>
 {:else if level === 'h2'}
 	<h2
+		{id}
 		class={headingClasses}
 		aria-label={ariaLabel}
 		aria-level={ariaLevel}
@@ -376,6 +383,7 @@ SPDX-License-Identifier: MIT
 	</h2>
 {:else if level === 'h3'}
 	<h3
+		{id}
 		class={headingClasses}
 		aria-label={ariaLabel}
 		aria-level={ariaLevel}
@@ -390,6 +398,7 @@ SPDX-License-Identifier: MIT
 	</h3>
 {:else if level === 'h4'}
 	<h4
+		{id}
 		class={headingClasses}
 		aria-label={ariaLabel}
 		aria-level={ariaLevel}
@@ -404,6 +413,7 @@ SPDX-License-Identifier: MIT
 	</h4>
 {:else if level === 'h5'}
 	<h5
+		{id}
 		class={headingClasses}
 		aria-label={ariaLabel}
 		aria-level={ariaLevel}
@@ -418,6 +428,7 @@ SPDX-License-Identifier: MIT
 	</h5>
 {:else if level === 'h6'}
 	<h6
+		{id}
 		class={headingClasses}
 		aria-label={ariaLabel}
 		aria-level={ariaLevel}

--- a/hexawebshare/src/components/core/typography/Text.svelte
+++ b/hexawebshare/src/components/core/typography/Text.svelte
@@ -113,6 +113,10 @@ opacity-50 cursor-not-allowed
 		 */
 		ariaHidden?: boolean;
 		/**
+		 * HTML id attribute
+		 */
+		id?: string;
+		/**
 		 * Additional CSS classes
 		 */
 		class?: string;
@@ -139,6 +143,7 @@ opacity-50 cursor-not-allowed
 		strikethrough = false,
 		ariaLabel,
 		ariaHidden = false,
+		id,
 		class: className = '',
 		children,
 		...props
@@ -216,6 +221,7 @@ opacity-50 cursor-not-allowed
 </script>
 
 <span
+	{id}
 	class={textClasses}
 	aria-label={ariaLabel}
 	aria-hidden={isDecorative || undefined}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR refactors the `EmptyState` component to follow the Component Composition & Reusability Principle by replacing raw HTML text elements (`<h3>`, `<p>`) with library typography components (`Heading`, `Text`).

**Changes:**
- Replaced title `<h3>` with `<Heading level="h3">` component
- Replaced description `<p>` with `<Text display="block">` component  
- Replaced loading `<p>` with `<Text size="sm" variant="muted">` component
- Added `id` prop support to `Heading` and `Text` components for accessibility

**Benefits:**
- Typography enhancements will automatically propagate to EmptyState
- Consistent text styling across empty states
- Better typography system integration
- Reduced code duplication

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format


✅ PR Title: `fix(EmptyState): replace raw headings and text with library components`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., fix/empty-state-use-library-components)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (pnpm format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran lint check (pnpm lint) successfully
- [x] I ran build successfully (pnpm build)
- [x] I ran Storybook build successfully (pnpm build-storybook)
- [x] I linked related issues using keywords like Closes #406
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues


```text
Closes #406
```
