### PR TITLE
fix: card replace raw text with library components

### DIFF
--- a/hexawebshare/src/components/core/layout/Card.stories.svelte
+++ b/hexawebshare/src/components/core/layout/Card.stories.svelte
@@ -24,25 +24,70 @@ SPDX-License-Identifier: MIT
 					'success',
 					'warning',
 					'error'
-				]
+				],
+				description: 'Color variant of the card (leave empty for default)'
 			},
 			shadowSize: {
 				control: { type: 'select' },
-				options: ['sm', 'md', 'lg', 'xl', '2xl']
+				options: ['sm', 'md', 'lg', 'xl', '2xl'],
+				description: 'Shadow size (only applies when shadow is true)'
 			},
-			bordered: { control: 'boolean' },
-			compact: { control: 'boolean' },
-			shadow: { control: 'boolean' },
-			side: { control: 'boolean' },
-			glass: { control: 'boolean' },
-			hoverable: { control: 'boolean' },
-			centered: { control: 'boolean' },
-			imageOverlay: { control: 'boolean' },
-			loading: { control: 'boolean' },
-			disabled: { control: 'boolean' },
-			title: { control: 'text' },
-			ariaLabel: { control: 'text' },
-			role: { control: 'text' }
+			bordered: {
+				control: 'boolean',
+				description: 'Add border to the card'
+			},
+			compact: {
+				control: 'boolean',
+				description: 'Compact card with reduced padding'
+			},
+			shadow: {
+				control: 'boolean',
+				description: 'Add shadow to the card'
+			},
+			side: {
+				control: 'boolean',
+				description: 'Side layout (figure on side instead of top)'
+			},
+			glass: {
+				control: 'boolean',
+				description: 'Make card glass/transparent effect'
+			},
+			hoverable: {
+				control: 'boolean',
+				description: 'Hoverable card with hover effects'
+			},
+			centered: {
+				control: 'boolean',
+				description: 'Center card body content'
+			},
+			imageOverlay: {
+				control: 'boolean',
+				description: 'Full image background'
+			},
+			loading: {
+				control: 'boolean',
+				description: 'Whether the card is in loading state'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Whether the card is disabled'
+			},
+			title: {
+				control: 'text',
+				description: 'Card title text'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for screen readers'
+			},
+			role: {
+				control: 'text',
+				description: 'ARIA role for the card'
+			},
+			class: {
+				control: 'text',
+				description: 'Additional CSS classes'
+			}
 		},
 		args: {
 			onclick: fn()
@@ -215,7 +260,6 @@ SPDX-License-Identifier: MIT
 	name="Playground"
 	args={{
 		title: 'Interactive Card',
-		variant: 'default',
 		shadowSize: 'md',
 		bordered: false,
 		compact: false,
@@ -227,6 +271,7 @@ SPDX-License-Identifier: MIT
 		imageOverlay: false,
 		loading: false,
 		disabled: false,
+		role: 'article',
 		onclick: fn()
 	}}
 />

--- a/hexawebshare/src/components/core/layout/Card.svelte
+++ b/hexawebshare/src/components/core/layout/Card.svelte
@@ -5,6 +5,8 @@ SPDX-License-Identifier: MIT
 
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import Heading from '../typography/Heading.svelte';
+	import Text from '../typography/Text.svelte';
 
 	/**
 	 * Props interface for the Card component
@@ -194,7 +196,7 @@ SPDX-License-Identifier: MIT
 	{#if loading}
 		<div class="card-body items-center justify-center">
 			<span class="loading loading-spinner loading-lg"></span>
-			<p class="text-sm opacity-70">Loading...</p>
+			<Text size="sm" class="opacity-70" text="Loading..." />
 		</div>
 	{:else}
 		{#if figure}
@@ -205,7 +207,7 @@ SPDX-License-Identifier: MIT
 
 		<div class={bodyClasses}>
 			{#if title}
-				<h2 class="card-title">{title}</h2>
+				<Heading level="h2" class="card-title" text={title} />
 			{/if}
 
 			{#if children}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR refactors the Card component to follow the Component Composition & Reusability Principle by replacing raw HTML text elements with library typography components (Heading and Text). Additionally, it improves the Storybook controls configuration to enable all component props to be controlled via the Storybook UI.

**Changes:**
- Replaced raw `<p>` tag (line 197) with `<Text>` component for loading state
- Replaced raw `<h2>` tag (line 208) with `<Heading>` component for card title
- Added missing `class` prop to argTypes for Storybook controls
- Added descriptions to all argTypes for better documentation
- Updated Playground story to include all controllable props

**Impact:**
- Typography enhancements will now automatically propagate to Card component
- Consistent text styling across all cards
- Better integration with the typography system
- Reduced code duplication
- All Card props are now controllable via Storybook controls

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

## ✏️ PR Title Format


✅ PR Title: `fix(Card): replace raw headings and text with library components`

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (`fix/card-replace-raw-text-with-library-components`)
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted (prettier format)
- [x] I ran static analysis (pnpm check) and resolved warnings
- [x] I ran tests successfully (build and Storybook build passed)
- [x] I updated / checked dependencies (no changes needed)
- [x] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I linked related issues using keywords like Closes #411
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

> If this PR addresses one or more issues, link them here:

```text
Closes #411
```

