### PR TITLE
feat(admin): implement AdminLayout component with strict mode and stories

### DIFF
--- a/hexawebshare/src/components/admin/layout/AdminLayout.stories.svelte
+++ b/hexawebshare/src/components/admin/layout/AdminLayout.stories.svelte
@@ -1,0 +1,686 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import AdminLayout from './AdminLayout.svelte';
+	import type { SidebarItem } from '../../core/overlay-navigation/Sidebar.svelte';
+	import { fn } from 'storybook/test';
+
+	// Sample sidebar items for stories
+	const defaultSidebarItems: SidebarItem[] = [
+		{ id: 'dashboard', label: 'Dashboard', icon: '📊', active: true },
+		{ id: 'users', label: 'Users', icon: '👥', badge: 24 },
+		{ id: 'products', label: 'Products', icon: '📦' },
+		{ id: 'orders', label: 'Orders', icon: '🛒', badge: 8, badgeVariant: 'success' },
+		{ id: 'analytics', label: 'Analytics', icon: '📈' },
+		{ id: 'settings', label: 'Settings', icon: '⚙️' }
+	];
+
+	const { Story } = defineMeta({
+		title: 'Admin/Layout/AdminLayout',
+		component: AdminLayout,
+		tags: ['autodocs'],
+		argTypes: {
+			variant: {
+				control: { type: 'select' },
+				options: ['default', 'bordered', 'filled'],
+				description: 'Visual variant of the layout'
+			},
+			sidebarWidth: {
+				control: { type: 'select' },
+				options: ['narrow', 'default', 'wide'],
+				description: 'Sidebar width variant'
+			},
+			sidebarCollapsed: {
+				control: 'boolean',
+				description: 'Whether the sidebar is collapsed'
+			},
+			sidebarCollapsible: {
+				control: 'boolean',
+				description: 'Whether the sidebar can be collapsed'
+			},
+			loading: {
+				control: 'boolean',
+				description: 'Whether the layout is in loading state'
+			},
+			disabled: {
+				control: 'boolean',
+				description: 'Whether the layout is disabled'
+			},
+			mobileSidebarOpen: {
+				control: 'boolean',
+				description: 'Whether the mobile sidebar drawer is open'
+			},
+			mobileDrawer: {
+				control: 'boolean',
+				description: 'Whether to show mobile sidebar as drawer'
+			},
+			sidebarTitle: {
+				control: 'text',
+				description: 'Sidebar title (required)'
+			},
+			sidebarSubtitle: {
+				control: 'text',
+				description: 'Sidebar subtitle (required)'
+			},
+			ariaLabel: {
+				control: 'text',
+				description: 'Accessible label for the layout (required)'
+			},
+			loadingLabel: {
+				control: 'text',
+				description: 'Accessible label for loading spinner (required)'
+			},
+			sidebarAriaLabel: {
+				control: 'text',
+				description: 'Accessible label for sidebar (required)'
+			}
+		},
+		args: {
+			sidebarItems: defaultSidebarItems,
+			sidebarTitle: 'Admin Panel',
+			sidebarSubtitle: 'Navigation',
+			variant: 'default',
+			sidebarWidth: 'default',
+			sidebarCollapsed: false,
+			sidebarCollapsible: true,
+			loading: false,
+			disabled: false,
+			mobileSidebarOpen: false,
+			mobileDrawer: true,
+			ariaLabel: 'Admin layout',
+			loadingLabel: 'Loading content',
+			sidebarAriaLabel: 'Admin navigation sidebar',
+			class: '',
+			onSidebarCollapse: fn()
+		}
+	});
+</script>
+
+<script lang="ts">
+	import Heading from '../../core/typography/Heading.svelte';
+	import Text from '../../core/typography/Text.svelte';
+	import Button from '../../core/buttons/Button.svelte';
+	import IconButton from '../../core/buttons/IconButton.svelte';
+
+	// Local state for mobile drawer stories
+	let mobileDrawerOpen = $state(false);
+	let playgroundMobileOpen = $state(false);
+</script>
+
+<!-- Story 1: Default Layout -->
+<Story name="Default">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Admin layout"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Admin Dashboard" />
+					<div class="flex items-center gap-2">
+						<IconButton variant="ghost" size="sm" ariaLabel="Notifications">🔔</IconButton>
+						<Button variant="primary" size="sm" label="New Item" />
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Welcome to Admin Panel" />
+					<Text text="This is the main content area of the admin layout." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 2: Without Sidebar -->
+<Story name="Without Sidebar">
+	{#snippet children()}
+		<AdminLayout
+			sidebarTitle=""
+			sidebarSubtitle=""
+			sidebarCollapsed={false}
+			sidebarCollapsible={false}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={false}
+			ariaLabel="Admin layout without sidebar"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Admin Dashboard" />
+					<Button variant="primary" size="sm" label="New Item" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Full Width Content" />
+					<Text text="Layout without sidebar for full-width content." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 3: Without Header -->
+<Story name="Without Header">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Admin layout without header"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<span></span>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Content Without Header" />
+					<Text text="Layout without header section." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 4: With Footer -->
+<Story name="With Footer">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Admin layout with footer"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Admin Dashboard" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Main Content" />
+					<Text text="Content area with footer below." class="mt-2" />
+				</div>
+			{/snippet}
+
+			{#snippet footer()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Text text="© 2025 Admin Panel" size="sm" variant="muted" />
+					<Text text="Version 1.0.0" size="sm" variant="muted" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 5: Collapsed Sidebar -->
+<Story name="Collapsed Sidebar">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={true}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Admin layout with collapsed sidebar"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Admin Dashboard" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Collapsed Sidebar" />
+					<Text text="Sidebar is collapsed to show more content space." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 6: Loading State -->
+<Story name="Loading State">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={true}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Admin layout in loading state"
+			loadingLabel="Loading admin content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Admin Dashboard" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Text text="This content is hidden during loading." />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 7: Bordered Variant -->
+<Story name="Bordered Variant">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="bordered"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Bordered admin layout"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Bordered Layout" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Bordered Variant" />
+					<Text text="Layout with border styling." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 8: Filled Variant -->
+<Story name="Filled Variant">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="filled"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Filled admin layout"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Filled Layout" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Filled Variant" />
+					<Text text="Layout with filled background styling." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 9: Narrow Sidebar -->
+<Story name="Narrow Sidebar">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="narrow"
+			variant="default"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Admin layout with narrow sidebar"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Narrow Sidebar" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Narrow Sidebar Width" />
+					<Text text="Sidebar with narrow width variant." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 10: Wide Sidebar -->
+<Story name="Wide Sidebar">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="wide"
+			variant="default"
+			loading={false}
+			disabled={false}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Admin layout with wide sidebar"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Wide Sidebar" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Wide Sidebar Width" />
+					<Text text="Sidebar with wide width variant." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 11: Disabled State -->
+<Story name="Disabled State">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={true}
+			mobileSidebarOpen={false}
+			mobileDrawer={true}
+			ariaLabel="Disabled admin layout"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Heading level="h1" size="xl" text="Disabled Layout" />
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Disabled State" />
+					<Text text="Layout in disabled state." class="mt-2" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 12: Mobile Drawer -->
+<Story name="Mobile Drawer">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={false}
+			bind:mobileSidebarOpen={mobileDrawerOpen}
+			mobileDrawer={true}
+			ariaLabel="Admin layout with mobile drawer"
+			loadingLabel="Loading content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<div class="flex items-center gap-2">
+						<IconButton
+							variant="ghost"
+							size="sm"
+							ariaLabel="Toggle mobile menu"
+							onclick={() => (mobileDrawerOpen = !mobileDrawerOpen)}
+							class="lg:hidden"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="h-6 w-6"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M4 6h16M4 12h16M4 18h16"
+								/>
+							</svg>
+						</IconButton>
+						<Heading level="h1" size="xl" text="Admin Dashboard" />
+					</div>
+					<div class="flex items-center gap-2">
+						<IconButton variant="ghost" size="sm" ariaLabel="Notifications">🔔</IconButton>
+						<Button variant="primary" size="sm" label="New Item" />
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Mobile Drawer Example" />
+					<Text
+						text="Click the hamburger menu icon (visible on mobile/tablet) to toggle the sidebar drawer."
+						class="mt-2"
+					/>
+					<div class="border-base-300 bg-base-200 mt-4 rounded-lg border p-4">
+						<Text text="Resize your browser window to test responsive behavior:" display="block" />
+						<ul class="mt-2 list-inside list-disc space-y-1">
+							<li><Text text="Desktop (1024px+): Sidebar visible on the left" /></li>
+							<li><Text text="Mobile/Tablet (<1024px): Sidebar hidden, use hamburger menu" /></li>
+						</ul>
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet footer()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Text text="© 2025 Admin Panel" size="sm" variant="muted" />
+					<Text text="Version 1.0.0" size="sm" variant="muted" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>
+
+<!-- Story 13: Playground (Interactive) -->
+<Story name="Playground">
+	{#snippet children()}
+		<AdminLayout
+			sidebarItems={defaultSidebarItems}
+			sidebarTitle="Admin Panel"
+			sidebarSubtitle="Navigation"
+			sidebarCollapsed={false}
+			sidebarCollapsible={true}
+			sidebarWidth="default"
+			variant="default"
+			loading={false}
+			disabled={false}
+			bind:mobileSidebarOpen={playgroundMobileOpen}
+			mobileDrawer={true}
+			ariaLabel="Interactive admin layout playground"
+			loadingLabel="Loading playground content"
+			sidebarAriaLabel="Admin navigation sidebar"
+			onSidebarCollapse={() => {}}
+			class=""
+		>
+			{#snippet header()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<div class="flex items-center gap-2">
+						<IconButton
+							variant="ghost"
+							size="sm"
+							ariaLabel="Toggle mobile menu"
+							onclick={() => (playgroundMobileOpen = !playgroundMobileOpen)}
+							class="lg:hidden"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="h-6 w-6"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M4 6h16M4 12h16M4 18h16"
+								/>
+							</svg>
+						</IconButton>
+						<Heading level="h1" size="xl" text="Admin Dashboard" />
+					</div>
+					<div class="flex items-center gap-2">
+						<IconButton variant="ghost" size="sm" ariaLabel="Notifications">🔔</IconButton>
+						<Button variant="primary" size="sm" label="New Item" />
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet children()}
+				<div class="p-6">
+					<Heading level="h2" text="Interactive Playground" />
+					<Text text="Use Storybook controls to customize the layout properties." class="mt-2" />
+					<Text
+						text="On mobile devices, click the hamburger menu to toggle the sidebar drawer."
+						class="mt-2"
+						variant="muted"
+					/>
+				</div>
+			{/snippet}
+
+			{#snippet footer()}
+				<div class="flex items-center justify-between px-6 py-4">
+					<Text text="© 2025 Admin Panel" size="sm" variant="muted" />
+					<Text text="Version 1.0.0" size="sm" variant="muted" />
+				</div>
+			{/snippet}
+		</AdminLayout>
+	{/snippet}
+</Story>

--- a/hexawebshare/src/components/admin/layout/AdminLayout.stories.svelte
+++ b/hexawebshare/src/components/admin/layout/AdminLayout.stories.svelte
@@ -78,25 +78,8 @@ SPDX-License-Identifier: MIT
 				control: 'text',
 				description: 'Accessible label for sidebar (required)'
 			}
-		},
-		args: {
-			sidebarItems: defaultSidebarItems,
-			sidebarTitle: 'Admin Panel',
-			sidebarSubtitle: 'Navigation',
-			variant: 'default',
-			sidebarWidth: 'default',
-			sidebarCollapsed: false,
-			sidebarCollapsible: true,
-			loading: false,
-			disabled: false,
-			mobileSidebarOpen: false,
-			mobileDrawer: true,
-			ariaLabel: 'Admin layout',
-			loadingLabel: 'Loading content',
-			sidebarAriaLabel: 'Admin navigation sidebar',
-			class: '',
-			onSidebarCollapse: fn()
 		}
+		// NOTE: args removed to prevent double-render with snippet-based components
 	});
 </script>
 

--- a/hexawebshare/src/components/admin/layout/AdminLayout.svelte
+++ b/hexawebshare/src/components/admin/layout/AdminLayout.svelte
@@ -215,68 +215,20 @@ SPDX-License-Identifier: MIT
 
 	<!-- Content Wrapper (Sidebar + Main Content) -->
 	<div class="admin-content-wrapper flex w-full flex-1 overflow-hidden">
-		{#if hasSidebar && mobileDrawer}
-			<!-- Mobile Drawer Implementation -->
-			<Drawer
-				open={mobileSidebarOpen}
-				side="left"
-				overlay={true}
-				closeOnBackdrop={true}
-				closeOnEscape={true}
-				ariaLabel={sidebarAriaLabel}
-				showCloseButton={true}
-			>
-				{#snippet children()}
-					{#if sidebar}
-						{@render sidebar()}
-					{:else if sidebarConfig}
-						<Sidebar {...sidebarConfig} />
-					{/if}
-				{/snippet}
-
-				{#snippet content()}
-					<div class="flex w-full flex-1 overflow-hidden">
-						<!-- Desktop Sidebar (hidden on mobile) -->
-						{#if sidebar}
-							<aside class="admin-sidebar hidden shrink-0 lg:block" aria-label={sidebarAriaLabel}>
-								{@render sidebar()}
-							</aside>
-						{:else if sidebarConfig}
-							<div class="hidden shrink-0 lg:block">
-								<Sidebar {...sidebarConfig} />
-							</div>
-						{/if}
-
-						<!-- Main Content Area -->
-						<main
-							class="admin-main-content bg-base-100 flex w-full min-w-0 flex-1 flex-col overflow-auto"
-						>
-							{#if loading}
-								<div class="flex flex-1 items-center justify-center">
-									<Spinner size="lg" variant="primary" ariaLabel={loadingLabel} />
-								</div>
-							{:else if children}
-								{@render children()}
-							{/if}
-						</main>
-					</div>
-				{/snippet}
-			</Drawer>
-		{:else}
-			<!-- Desktop Only Layout (no mobile drawer) -->
-			<div class="flex w-full flex-1 overflow-hidden">
-				<!-- Sidebar Section -->
+		{#if hasSidebar}
+			<!-- Desktop Layout (hidden on mobile) - No Drawer to avoid DaisyUI double-render -->
+			<div class="hidden w-full flex-1 overflow-hidden lg:flex">
 				{#if sidebar}
-					<aside class="admin-sidebar hidden shrink-0 lg:block" aria-label={sidebarAriaLabel}>
+					<aside class="admin-sidebar shrink-0" aria-label={sidebarAriaLabel}>
 						{@render sidebar()}
 					</aside>
 				{:else if sidebarConfig}
-					<div class="hidden shrink-0 lg:block">
+					<div class="shrink-0">
 						<Sidebar {...sidebarConfig} />
 					</div>
 				{/if}
 
-				<!-- Main Content Area -->
+				<!-- Main Content Area (Desktop) -->
 				<main
 					class="admin-main-content bg-base-100 flex w-full min-w-0 flex-1 flex-col overflow-auto"
 				>
@@ -289,6 +241,72 @@ SPDX-License-Identifier: MIT
 					{/if}
 				</main>
 			</div>
+
+			<!-- Mobile Layout (hidden on desktop) - Drawer for sidebar -->
+			{#if mobileDrawer}
+				<div class="flex w-full flex-1 overflow-hidden lg:hidden">
+					<Drawer
+						open={mobileSidebarOpen}
+						side="left"
+						overlay={true}
+						closeOnBackdrop={true}
+						closeOnEscape={true}
+						ariaLabel={sidebarAriaLabel}
+						showCloseButton={true}
+					>
+						{#snippet children()}
+							{#if sidebar}
+								{@render sidebar()}
+							{:else if sidebarConfig}
+								<Sidebar {...sidebarConfig} />
+							{/if}
+						{/snippet}
+
+						{#snippet content()}
+							<!-- Main Content Area (Mobile) -->
+							<main
+								class="admin-main-content bg-base-100 flex w-full min-w-0 flex-1 flex-col overflow-auto"
+							>
+								{#if loading}
+									<div class="flex flex-1 items-center justify-center">
+										<Spinner size="lg" variant="primary" ariaLabel={loadingLabel} />
+									</div>
+								{:else if children}
+									{@render children()}
+								{/if}
+							</main>
+						{/snippet}
+					</Drawer>
+				</div>
+			{:else}
+				<!-- Mobile without Drawer -->
+				<div class="flex w-full flex-1 overflow-hidden lg:hidden">
+					<main
+						class="admin-main-content bg-base-100 flex w-full min-w-0 flex-1 flex-col overflow-auto"
+					>
+						{#if loading}
+							<div class="flex flex-1 items-center justify-center">
+								<Spinner size="lg" variant="primary" ariaLabel={loadingLabel} />
+							</div>
+						{:else if children}
+							{@render children()}
+						{/if}
+					</main>
+				</div>
+			{/if}
+		{:else}
+			<!-- No Sidebar Layout -->
+			<main
+				class="admin-main-content bg-base-100 flex w-full min-w-0 flex-1 flex-col overflow-auto"
+			>
+				{#if loading}
+					<div class="flex flex-1 items-center justify-center">
+						<Spinner size="lg" variant="primary" ariaLabel={loadingLabel} />
+					</div>
+				{:else if children}
+					{@render children()}
+				{/if}
+			</main>
 		{/if}
 	</div>
 

--- a/hexawebshare/src/components/admin/layout/AdminLayout.svelte
+++ b/hexawebshare/src/components/admin/layout/AdminLayout.svelte
@@ -2,3 +2,304 @@
 SPDX-FileCopyrightText: 2025 hexaTune LLC
 SPDX-License-Identifier: MIT
 -->
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { SidebarItem } from '../../core/overlay-navigation/Sidebar.svelte';
+	import Sidebar from '../../core/overlay-navigation/Sidebar.svelte';
+	import Drawer from '../../core/overlay-navigation/Drawer.svelte';
+	import Spinner from '../../core/feedback/Spinner.svelte';
+
+	/**
+	 * Props interface for AdminLayout - Pioneer Strict Mode
+	 * No default values are allowed. All behavioral and text props are required.
+	 * This component serves as a blueprint for future library standards.
+	 */
+	interface Props {
+		// --- Snippets ---
+		/**
+		 * Header/topbar content snippet (logo, navigation, user menu, etc.)
+		 * Required: Must be provided by consumer
+		 */
+		header: Snippet;
+		/**
+		 * Main content area snippet
+		 * Required: Must be provided by consumer
+		 */
+		children: Snippet;
+		/**
+		 * Sidebar content snippet (custom sidebar implementation)
+		 * Optional: Alternative to sidebarItems prop
+		 */
+		sidebar?: Snippet;
+		/**
+		 * Footer content snippet
+		 * Optional: Render footer section when provided
+		 */
+		footer?: Snippet;
+
+		// --- Sidebar Configuration ---
+		/**
+		 * Array of sidebar items for programmatic sidebar rendering
+		 * Optional: Alternative to sidebar snippet
+		 */
+		sidebarItems?: SidebarItem[];
+		/**
+		 * Sidebar title text
+		 * Required: No embedded strings allowed
+		 */
+		sidebarTitle: string;
+		/**
+		 * Sidebar subtitle text
+		 * Required: No embedded strings allowed
+		 */
+		sidebarSubtitle: string;
+		/**
+		 * Whether the sidebar is collapsed
+		 * Required: Consumer must control state explicitly
+		 */
+		sidebarCollapsed: boolean;
+		/**
+		 * Whether the sidebar can be collapsed
+		 * Required: Consumer must specify behavior
+		 */
+		sidebarCollapsible: boolean;
+		/**
+		 * Sidebar width variant
+		 * Required: Consumer must specify width
+		 */
+		sidebarWidth: 'narrow' | 'default' | 'wide';
+
+		// --- Layout States & Variants ---
+		/**
+		 * Visual variant of the layout
+		 * Required: Consumer must specify variant
+		 */
+		variant: 'default' | 'bordered' | 'filled';
+		/**
+		 * Whether the layout is in loading state
+		 * Required: Consumer must control loading state
+		 */
+		loading: boolean;
+		/**
+		 * Whether the layout is disabled
+		 * Required: Consumer must specify disabled state
+		 */
+		disabled: boolean;
+
+		// --- Mobile / Drawer Configuration ---
+		/**
+		 * Whether the mobile sidebar drawer is open
+		 * Required: Consumer must control mobile drawer state
+		 */
+		mobileSidebarOpen: boolean;
+		/**
+		 * Whether to show mobile sidebar as drawer
+		 * Required: Consumer must specify mobile behavior
+		 */
+		mobileDrawer: boolean;
+
+		// --- Accessibility (Strict: No embedded strings) ---
+		/**
+		 * Accessible label for the admin layout container
+		 * Required: No embedded strings - must be provided for i18n support
+		 */
+		ariaLabel: string;
+		/**
+		 * Accessible label for the loading spinner
+		 * Required: No embedded strings - must be provided for i18n support
+		 */
+		loadingLabel: string;
+		/**
+		 * Accessible label for the sidebar navigation
+		 * Required: No embedded strings - must be provided for i18n support
+		 */
+		sidebarAriaLabel: string;
+
+		// --- Callbacks ---
+		/**
+		 * Callback when sidebar collapse state changes
+		 * Required: Consumer must handle sidebar collapse events
+		 */
+		onSidebarCollapse: (collapsed: boolean) => void;
+
+		// --- Styling ---
+		/**
+		 * Additional CSS classes
+		 * Required: Pass empty string if no custom classes needed
+		 */
+		class: string;
+	}
+
+	const {
+		header,
+		children,
+		sidebar,
+		footer,
+		sidebarItems,
+		sidebarTitle,
+		sidebarSubtitle,
+		sidebarCollapsed = $bindable(),
+		sidebarCollapsible,
+		sidebarWidth,
+		variant,
+		loading,
+		disabled,
+		mobileSidebarOpen = $bindable(),
+		mobileDrawer,
+		ariaLabel,
+		loadingLabel,
+		sidebarAriaLabel,
+		onSidebarCollapse,
+		class: className,
+		...props
+	}: Props = $props();
+
+	// Derived classes using static strings for JIT optimization
+	let layoutClasses = $derived(
+		[
+			'admin-layout',
+			'flex',
+			'flex-col',
+			'w-full',
+			'min-h-screen',
+			'bg-base-100',
+			variant === 'bordered' && 'border border-base-300',
+			variant === 'filled' && 'bg-base-200',
+			disabled && 'opacity-50 pointer-events-none',
+			className
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	// Determine if sidebar should be rendered
+	let hasSidebar = $derived(sidebar || (sidebarItems && sidebarItems.length > 0));
+
+	// Abstracted configuration for Sidebar component to avoid repetition
+	let sidebarConfig = $derived.by(() => {
+		if (!hasSidebar || sidebar) return null;
+		if (sidebarItems && sidebarItems.length > 0) {
+			return {
+				items: sidebarItems,
+				title: sidebarTitle,
+				subtitle: sidebarSubtitle,
+				width: sidebarWidth,
+				collapsed: sidebarCollapsed,
+				collapsible: sidebarCollapsible,
+				onCollapse: onSidebarCollapse,
+				ariaLabel: sidebarAriaLabel
+			};
+		}
+		return null;
+	});
+</script>
+
+<!--
+	NOTE: Structural HTML elements (div, header, main, footer, aside) are used
+	as semantic containers following AGENTS.md guidelines for "structural containers
+	with no semantic meaning". These are layout primitives that don't have
+	equivalent library components and are necessary for proper HTML semantics.
+-->
+<div class={layoutClasses} role="main" aria-label={ariaLabel} aria-busy={loading} {...props}>
+	<!-- Header Section - Defensive check for robustness -->
+	{#if header}
+		<header
+			class="admin-header border-base-300 bg-base-100 sticky top-0 z-40 shrink-0 border-b"
+			role="banner"
+			aria-label={ariaLabel}
+		>
+			{@render header()}
+		</header>
+	{/if}
+
+	<!-- Content Wrapper (Sidebar + Main Content) -->
+	<div class="admin-content-wrapper flex w-full flex-1 overflow-hidden">
+		{#if hasSidebar && mobileDrawer}
+			<!-- Mobile Drawer Implementation -->
+			<Drawer
+				open={mobileSidebarOpen}
+				side="left"
+				overlay={true}
+				closeOnBackdrop={true}
+				closeOnEscape={true}
+				ariaLabel={sidebarAriaLabel}
+				showCloseButton={true}
+			>
+				{#snippet children()}
+					{#if sidebar}
+						{@render sidebar()}
+					{:else if sidebarConfig}
+						<Sidebar {...sidebarConfig} />
+					{/if}
+				{/snippet}
+
+				{#snippet content()}
+					<div class="flex w-full flex-1 overflow-hidden">
+						<!-- Desktop Sidebar (hidden on mobile) -->
+						{#if sidebar}
+							<aside class="admin-sidebar hidden shrink-0 lg:block" aria-label={sidebarAriaLabel}>
+								{@render sidebar()}
+							</aside>
+						{:else if sidebarConfig}
+							<div class="hidden shrink-0 lg:block">
+								<Sidebar {...sidebarConfig} />
+							</div>
+						{/if}
+
+						<!-- Main Content Area -->
+						<main
+							class="admin-main-content bg-base-100 flex w-full min-w-0 flex-1 flex-col overflow-auto"
+						>
+							{#if loading}
+								<div class="flex flex-1 items-center justify-center">
+									<Spinner size="lg" variant="primary" ariaLabel={loadingLabel} />
+								</div>
+							{:else if children}
+								{@render children()}
+							{/if}
+						</main>
+					</div>
+				{/snippet}
+			</Drawer>
+		{:else}
+			<!-- Desktop Only Layout (no mobile drawer) -->
+			<div class="flex w-full flex-1 overflow-hidden">
+				<!-- Sidebar Section -->
+				{#if sidebar}
+					<aside class="admin-sidebar hidden shrink-0 lg:block" aria-label={sidebarAriaLabel}>
+						{@render sidebar()}
+					</aside>
+				{:else if sidebarConfig}
+					<div class="hidden shrink-0 lg:block">
+						<Sidebar {...sidebarConfig} />
+					</div>
+				{/if}
+
+				<!-- Main Content Area -->
+				<main
+					class="admin-main-content bg-base-100 flex w-full min-w-0 flex-1 flex-col overflow-auto"
+				>
+					{#if loading}
+						<div class="flex flex-1 items-center justify-center">
+							<Spinner size="lg" variant="primary" ariaLabel={loadingLabel} />
+						</div>
+					{:else if children}
+						{@render children()}
+					{/if}
+				</main>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Footer Section - Optional -->
+	{#if footer}
+		<footer
+			class="admin-footer border-base-300 bg-base-100 shrink-0 border-t"
+			role="contentinfo"
+			aria-label={ariaLabel}
+		>
+			{@render footer()}
+		</footer>
+	{/if}
+</div>

--- a/hexawebshare/src/lib/index.ts
+++ b/hexawebshare/src/lib/index.ts
@@ -102,6 +102,10 @@ export { default as MutedText } from '../components/core/typography/MutedText.sv
 export { default as Paragraph } from '../components/core/typography/Paragraph.svelte';
 export { default as Text } from '../components/core/typography/Text.svelte';
 
+// Admin / Layout
+export { default as AdminLayout } from '../components/admin/layout/AdminLayout.svelte';
+export type { SidebarItem } from '../components/core/overlay-navigation/Sidebar.svelte';
+
 // Utility / Utility
 export { default as FooterBar } from '../components/utility/utility/FooterBar.svelte';
 export type {


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This PR introduces the `AdminLayout` component for the `admin/layout` module.

The component is implemented in **Pioneer Strict Mode**, serving as a reference layout that enforces the project's highest architectural standards: explicit configuration, composition-first design, and full i18n/a11y compliance.

- **Strict configuration**: No default values. All visual and behavioral options (variants, loading state, widths) are required props.
- **No embedded strings**: All user-facing and assistive text (`ariaLabel`, `loadingLabel`, `sidebarAriaLabel`) is passed explicitly for i18n.
- **Core components only**: Built using `Sidebar`, `Drawer`, and `Spinner`.
- **Composition-first layout**: Header, footer, and sidebar are injected via snippets to avoid layout-level coupling.
- **Svelte 5 runes**: Uses `$props`, `$derived`, `$derived.by`, and `$bindable`.

---

## 🧩 Affected Module(s)

- [x] Source Code
- [ ] Documentation
- [ ] CI / Infra

---

---

## ✅ Checklist

- [x] My branch name follows format: `feat/admin-layout-implementation`
- [x] My PR title starts with one of the approved types listed above
- [x] My code is formatted using Prettier (`pnpm format`)
- [x] I ran static analysis (`pnpm check`) and resolved warnings
- [x] I linked related issues using keywords like `Closes #219`
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #219

---